### PR TITLE
[FIX] Toast 컴포넌트 관리 방식 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ src/mocks/data/*
 # Environment variables
 .env
 .env.* 
+
+# iOS 보안 파일
+ios/nailian/Secrets.plist
+ios/Config.xcconfig 

--- a/App.tsx
+++ b/App.tsx
@@ -7,9 +7,15 @@
 
 import React from 'react';
 import AppNavigation from './src/app/providers/navigation';
+import { ToastContainer } from './src/shared/ui/Toast';
 
 function App(): React.JSX.Element {
-  return <AppNavigation />;
+  return (
+    <>
+      <AppNavigation />
+      <ToastContainer />
+    </>
+  );
 }
 
 export default App;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,8 @@
 PODS:
+  - Alamofire (5.9.1)
   - boost (1.84.0)
+  - BVLinearGradient (2.8.3):
+    - React-Core
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.76.6)
   - fmt (9.1.0)
@@ -7,6 +10,26 @@ PODS:
   - hermes-engine (0.76.6):
     - hermes-engine/Pre-built (= 0.76.6)
   - hermes-engine/Pre-built (0.76.6)
+  - kakao-login (5.4.1):
+    - KakaoSDKAuth (= 2.22.0)
+    - KakaoSDKCommon (= 2.22.0)
+    - KakaoSDKUser (= 2.22.0)
+    - React
+  - KakaoSDKAuth (2.22.0):
+    - KakaoSDKCommon (= 2.22.0)
+  - KakaoSDKCommon (2.22.0):
+    - KakaoSDKCommon/Common (= 2.22.0)
+    - KakaoSDKCommon/Network (= 2.22.0)
+  - KakaoSDKCommon/Common (2.22.0)
+  - KakaoSDKCommon/Network (2.22.0):
+    - Alamofire (~> 5.9.0)
+    - KakaoSDKCommon/Common (= 2.22.0)
+  - KakaoSDKUser (2.22.0):
+    - KakaoSDKAuth (= 2.22.0)
+  - onnxruntime-c (1.20.0)
+  - onnxruntime-react-native (1.20.1):
+    - onnxruntime-c
+    - React-Core
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1242,6 +1265,72 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-safe-area-context (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common (= 5.2.0)
+    - react-native-safe-area-context/fabric (= 5.2.0)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/common (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/fabric (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.76.6)
   - React-NativeModulesApple (0.76.6):
     - glog
@@ -1509,16 +1598,130 @@ PODS:
     - React-logger (= 0.76.6)
     - React-perflogger (= 0.76.6)
     - React-utils (= 0.76.6)
+  - RNFS (2.20.0):
+    - React-Core
+  - RNKeychain (9.2.3):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNScreens (4.6.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNScreens/common (= 4.6.0)
+    - Yoga
+  - RNScreens/common (4.6.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNSVG (15.11.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNSVG/common (= 15.11.1)
+    - Yoga
+  - RNSVG/common (15.11.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
+  - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - "kakao-login (from `../node_modules/@react-native-seoul/kakao-login`)"
+  - onnxruntime-react-native (from `../node_modules/onnxruntime-react-native`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -1550,6 +1753,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -1577,15 +1781,26 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNFS (from `../node_modules/react-native-fs`)
+  - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNScreens (from `../node_modules/react-native-screens`)
+  - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
+    - Alamofire
+    - KakaoSDKAuth
+    - KakaoSDKCommon
+    - KakaoSDKUser
+    - onnxruntime-c
     - SocketRocket
 
 EXTERNAL SOURCES:
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
+  BVLinearGradient:
+    :path: "../node_modules/react-native-linear-gradient"
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
@@ -1597,6 +1812,10 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2024-11-12-RNv0.76.2-5b4aa20c719830dcf5684832b89a6edb95ac3d64
+  kakao-login:
+    :path: "../node_modules/@react-native-seoul/kakao-login"
+  onnxruntime-react-native:
+    :path: "../node_modules/onnxruntime-react-native"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -1655,6 +1874,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   React-nativeconfig:
     :path: "../node_modules/react-native/ReactCommon"
   React-NativeModulesApple:
@@ -1709,72 +1930,93 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNFS:
+    :path: "../node_modules/react-native-fs"
+  RNKeychain:
+    :path: "../node_modules/react-native-keychain"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
+  RNSVG:
+    :path: "../node_modules/react-native-svg"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be509404b5de73a64a74284edcaf73a5d1e128b1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 1949ca944b195a8bde7cbf6316b9068e19cf53c6
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  kakao-login: 39d7c13140ad97c54f9d42893d32ab4a1476420a
+  KakaoSDKAuth: 569b377eda622d93d4575240b8031cd658163eef
+  KakaoSDKCommon: d57127c339fc79e73aa8b236a4c77211c29924f1
+  KakaoSDKUser: 043bcd7e91454ebf3bf64f150c430e6f65f0a08d
+  onnxruntime-c: 07cfff40dda7e1c54a4350bb2ad226c63150fce3
+  onnxruntime-react-native: 381e407520842f6ba8fbc3b50e2478b52a6eaa3a
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 063fc281b30b7dc944c98fe53a7e266dab1a8706
   RCTRequired: 8eda2a5a745f6081157a4f34baac40b65fe02b31
   RCTTypeSafety: 0f96bf6c99efc33eb43352212703854933f22930
   React: 1d3d5bada479030961d513fb11e42659b30e97ff
   React-callinvoker: 682c610b9e9d3b93bd8d0075eacb2e6aa304d3e0
-  React-Core: 10420b32e62acf6b3aa0a570e45566001175c777
-  React-CoreModules: aad977a7dbff83aa707c4045e5db81446a511cca
-  React-cxxreact: 1bee1b97e7d537f1a33d9eb68c9426c1fc1a4e3c
+  React-Core: 9f33c0fc7776a5796d4dae09c363bd58e6a27efe
+  React-CoreModules: 91afb654834f0a1f48fb26dd1f4d1a1460c44def
+  React-cxxreact: c7491114266a70f8215306f1d0c4b54a811e77cf
   React-debug: 4ae2e95c2d392cca29939a3a2f2b4320ddff3e59
-  React-defaultsnativemodule: b585565214178c5780b54e4d56815d65782eac81
-  React-domnativemodule: 03fd1847e49505aa9024acbe4f0811e441dc89a2
-  React-Fabric: fc0898bb601b03ed41ab0df3e7b1a4acd05a6cff
-  React-FabricComponents: 13e78253b210d112b3ffddca5b7323db7f254358
-  React-FabricImage: a86ff938570a06c2a9fbf00ff0b00195f0bd4aba
+  React-defaultsnativemodule: 43d27f1844b4c18fc03fa4fa35ea2f1c48d64237
+  React-domnativemodule: bca178dd0ce1532f75be783f6f2923f675a778ae
+  React-Fabric: d6bc0222335270eb76c28dd5036c03a010c04d51
+  React-FabricComponents: 05eec9e2cf998be793daaee8fa8a8ea6d1187785
+  React-FabricImage: 3a12374b0aedda71c7ef6bd64b59479b8bb3fe05
   React-featureflags: 5670e0dcdc17ba2515963d117dacc13d5b69c431
-  React-featureflagsnativemodule: 79dea40c60cdc0356aadc67a099bba0af8c34e4f
-  React-graphics: 04eed50a115e750e4644c1e955f32bec57f6a235
-  React-hermes: add932964f5ef024c86352dcc0dc427e6309642e
-  React-idlecallbacksnativemodule: 3e8d5085a21eb2f70ac64ff9817f8f8a603518a9
-  React-ImageManager: 3239badd14cc602baf836b5d7151ffa90393deae
-  React-jserrorhandler: 81ac36638e02c33a9df0bdbeec464d2e699ac8a9
-  React-jsi: 690f3742db66cab8d5219bcfbc19fee112c6bb0c
-  React-jsiexecutor: a060f7e989da21e2478f652d7799e3b5ae5db262
-  React-jsinspector: 0eb6ea6f6b1e42edeab4bcad092d37ef748e337a
-  React-jsitracing: 737a69a469e2bc821cf8ae11977bded522393719
-  React-logger: 162c09cc432b02d4a0db31b1d98f6df5243a2679
-  React-Mapbuffer: f760d2229640be48cb3c2d4832b5bbc3018123fc
-  React-microtasksnativemodule: 1364ae5354f51b3ecee8eb718b5b6d1686d2ff4d
+  React-featureflagsnativemodule: bb13129d1427327b2eb8cc13d3879363a4cd8326
+  React-graphics: 659968f797257c0071ddff28a2d094c8e5c5899c
+  React-hermes: 6eb81c6f72c25d9058b6030227d0fcc1f741a807
+  React-idlecallbacksnativemodule: 551b7a89b46041c746640fe13eacf39c1b169709
+  React-ImageManager: e3d0270c82bf39432da2aff2fcd60dd16b308689
+  React-jserrorhandler: f60c9b68b4d4ac1449bddc2553610708e939ddee
+  React-jsi: 47528a2928f38fe15e3d06a96de886e1a779ffc7
+  React-jsiexecutor: 88a141c4dc821e1b2aa7ecc7d6af7b186e8455a2
+  React-jsinspector: c26cf4118ea7c1aae721d2cde5acf3b2cdceb814
+  React-jsitracing: 810d0465c3455e352a71147c18332b1cba1d1410
+  React-logger: d42a53754a7252cc7a851315f0da2e46b450ea92
+  React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
+  React-microtasksnativemodule: 36341e09dcd1df535503e6ed2ddf88f10da56d52
+  react-native-safe-area-context: 5e53e2b0fc3a2994ad0c89a2486e545b6566d8c4
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
-  React-NativeModulesApple: 771cc40b086281b820fe455fedebbe4341fd0c90
-  React-perflogger: 4e80a5b8d61dfb38024e7d5b8efaf9ce1037d31f
-  React-performancetimeline: 1dcacc31d81f790f43a2d434ec95b0f864582329
+  React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521
+  React-perflogger: f260e2de95f9dbd002035251559c13bf1f0643d4
+  React-performancetimeline: 957075cead70fe9536a327eb4f842b3d8982f2ec
   React-RCTActionSheet: ed5a845eae98fe455b9a1d71f057d626e2f3f1c5
-  React-RCTAnimation: 0cda303ef8ca5a2d0ee9e425f188cc9fc1d2e20f
-  React-RCTAppDelegate: 1edcdebdaebf5120bdaa9d54bc40789714be3719
-  React-RCTBlob: dab83a3c22210e5c7a8267834c68e6cf94bc1ce2
-  React-RCTFabric: 19ba31d6b913b8b4aa8b27e4d6f5dc8ebd93a438
-  React-RCTImage: b9c3d2cff3b8214322022cdf8afb92ff978bb92e
-  React-RCTLinking: e58c4fa216f9ac87ed3d4a0cce03905df67adec0
-  React-RCTNetwork: 9f206fa039e107f51ddfac133df79105643ea2bd
-  React-RCTSettings: c7663cfcb3531cd438b8f73e98cd2d982a4bbd72
-  React-RCTText: cfee29316f1049f016cbd81328a89a8a07410bba
-  React-RCTVibration: 20f5efc1b05cd3f5f7ea03489dd3766c890fb493
+  React-RCTAnimation: a49bd2c28c3f32b1d01ff1163603aee3d420ce42
+  React-RCTAppDelegate: f7aa2f938a6673cfd2a76e76fea8c4b38a4a5bec
+  React-RCTBlob: 8ddf30f97222f4d8227f64428349fd8252292cb5
+  React-RCTFabric: 51fb64f7ca7ca2fa334433ba6d4f12750a481cf1
+  React-RCTImage: 077a25f3a9a6b79938a01c2cfae05ea5f07fc584
+  React-RCTLinking: 0c8415c600942454d663c4c4dc0d3b00aa7ba5e5
+  React-RCTNetwork: 42a3c6fb5318dcc9f8796f43de081799fb905021
+  React-RCTSettings: 1028522e45192515bd8c5308752d3270ee95fd66
+  React-RCTText: 29ef786d78f69ec5b571634ef2ddd6ec177c958a
+  React-RCTVibration: 97859ed50816369f4830f623dfac8dc9877f3c5c
   React-rendererconsistency: ccd50d5ee6544b26cd11fff5ad1112c5058a0064
-  React-rendererdebug: d8f43065459c2095f27a173121f03dcd1d1b08e5
+  React-rendererdebug: 2092a1207a0023ac30877f4f730b403bfaf5ccbe
   React-rncore: bfe554cb773978e8b94898866964c9579cb0c70c
-  React-RuntimeApple: 89c319b1610d4ca8895642cf0eae1188bf864270
-  React-RuntimeCore: 30399cbd2368f7e031692875275984fa42142601
+  React-RuntimeApple: 80949ebe7e6a94296e0168a940832d2029b66982
+  React-RuntimeCore: f04b5d1eb0534a4f4f46bc76a938a9360ad91024
   React-runtimeexecutor: 26a9d14619ec1359470df391be9abb7c80a21b2b
-  React-RuntimeHermes: c78f07b7a599c1c9a889189c02436600e72c8b27
-  React-runtimescheduler: 9f6b0b85154ed8a17a899cd1bab258a26c8db2cd
+  React-RuntimeHermes: 91c2a67a99f316f11a08d3d9280ab4c9fae59b56
+  React-runtimescheduler: 76bb85f5ba01e800b4970fbc84eeaf10756c50c4
   React-timing: c9c7c0fe2fdfc433ef208889b6191dfb45457d68
-  React-utils: e6697b03f21c7ac57b075d848cda7882662cabf7
-  ReactCodegen: 484b223748d7489d7036db1cbf79896d297e33a7
-  ReactCommon: 832cdd669aeecd430d9ca1975d15676b38d0b263
+  React-utils: 1b14c41c3edf4d96db1247a78e0ad96e7ceea011
+  ReactCodegen: 0a0eef9c8cd84c932ae1868832086c6441811e84
+  ReactCommon: 3c1c8c6d777103c0e60e37c6c5f08e828e2a77c9
+  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
+  RNKeychain: 2b7e8a3e99060ee0d65a51b69187f188e3d58968
+  RNScreens: 771cbeddcd8e11d1d176f1b637e8846a2036390e
+  RNSVG: c50d29abf38abbf48ebfc50b6258f81099aeabae
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: be6f55a028e86c83ae066f018e9b5d24ffc45436
 

--- a/ios/nailian.xcodeproj/project.pbxproj
+++ b/ios/nailian.xcodeproj/project.pbxproj
@@ -15,15 +15,10 @@
 		473BFEFAD123086068F6BFCD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		7699B88040F8A987B510C191 /* libPods-nailian-nailianTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-nailian-nailianTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		F9D6DEC360E54EF3BF27FC23 /* Pretendard-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41B58996C11440A3B7EB6B13 /* Pretendard-Black.ttf */; };
-		428DD93CD3F643D999837A22 /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6B8B69C2F6D148E2A281ACF1 /* Pretendard-Bold.ttf */; };
-		7C0698ED50BE4F1BBA05CEF7 /* Pretendard-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C8D7FE748B344A429ACD3F64 /* Pretendard-ExtraBold.ttf */; };
-		6BF40E32CB644B8D9B102545 /* Pretendard-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */; };
-		571A77FE07BA4527A7363332 /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 57522F6DF8484439901F7D57 /* Pretendard-Light.ttf */; };
-		43B8ED3FBD0547FAA4A646D0 /* Pretendard-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CB4F9DE9ABA54B6093085640 /* Pretendard-Medium.ttf */; };
-		16E394A3DFE44FD398D9BBE7 /* Pretendard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 157C389F8C124FB0B424A86E /* Pretendard-Regular.ttf */; };
-		4181259A48D84C55A6E820C9 /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */; };
-		F7EFBAC9D88F4B3486FC3C0D /* Pretendard-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */; };
+		E16EA9A12D7815BF0056AA4B /* libRNKeychain.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */; };
+		E1F801282D5DBBC600266514 /* libKakaoSDKAuth.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1F801272D5DBBC600266514 /* libKakaoSDKAuth.a */; };
+		E1F8012A2D5DBBC600266514 /* libKakaoSDKCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1F801292D5DBBC600266514 /* libKakaoSDKCommon.a */; };
+		E1F8012C2D5DBBC600266514 /* libKakaoSDKUser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1F8012B2D5DBBC600266514 /* libKakaoSDKUser.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,23 +42,27 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = nailian/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = nailian/main.m; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = nailian/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		157C389F8C124FB0B424A86E /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Regular.ttf"; path = "../src/shared/assets/fonts/Pretendard-Regular.ttf"; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-nailian-nailianTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-nailian-nailianTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-nailian.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nailian.debug.xcconfig"; path = "Target Support Files/Pods-nailian/Pods-nailian.debug.xcconfig"; sourceTree = "<group>"; };
+		41B58996C11440A3B7EB6B13 /* Pretendard-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Black.ttf"; path = "../src/shared/assets/fonts/Pretendard-Black.ttf"; sourceTree = "<group>"; };
+		4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraLight.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraLight.ttf"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-nailian.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nailian.release.xcconfig"; path = "Target Support Files/Pods-nailian/Pods-nailian.release.xcconfig"; sourceTree = "<group>"; };
+		57522F6DF8484439901F7D57 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Light.ttf"; path = "../src/shared/assets/fonts/Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-nailian-nailianTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nailian-nailianTests.debug.xcconfig"; path = "Target Support Files/Pods-nailian-nailianTests/Pods-nailian-nailianTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-nailian.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-nailian.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B8B69C2F6D148E2A281ACF1 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Bold.ttf"; path = "../src/shared/assets/fonts/Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = nailian/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-nailian-nailianTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nailian-nailianTests.release.xcconfig"; path = "Target Support Files/Pods-nailian-nailianTests/Pods-nailian-nailianTests.release.xcconfig"; sourceTree = "<group>"; };
+		C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-SemiBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-SemiBold.ttf"; sourceTree = "<group>"; };
+		C8D7FE748B344A429ACD3F64 /* Pretendard-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraBold.ttf"; sourceTree = "<group>"; };
+		CB4F9DE9ABA54B6093085640 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.ttf"; path = "../src/shared/assets/fonts/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
+		E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libRNKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1F801272D5DBBC600266514 /* libKakaoSDKAuth.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libKakaoSDKAuth.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1F801292D5DBBC600266514 /* libKakaoSDKCommon.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libKakaoSDKCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1F8012B2D5DBBC600266514 /* libKakaoSDKUser.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libKakaoSDKUser.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		41B58996C11440A3B7EB6B13 /* Pretendard-Black.ttf */ = {isa = PBXFileReference; name = "Pretendard-Black.ttf"; path = "../src/shared/assets/fonts/Pretendard-Black.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		6B8B69C2F6D148E2A281ACF1 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; name = "Pretendard-Bold.ttf"; path = "../src/shared/assets/fonts/Pretendard-Bold.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		C8D7FE748B344A429ACD3F64 /* Pretendard-ExtraBold.ttf */ = {isa = PBXFileReference; name = "Pretendard-ExtraBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraBold.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */ = {isa = PBXFileReference; name = "Pretendard-ExtraLight.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraLight.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		57522F6DF8484439901F7D57 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; name = "Pretendard-Light.ttf"; path = "../src/shared/assets/fonts/Pretendard-Light.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		CB4F9DE9ABA54B6093085640 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; name = "Pretendard-Medium.ttf"; path = "../src/shared/assets/fonts/Pretendard-Medium.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		157C389F8C124FB0B424A86E /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; name = "Pretendard-Regular.ttf"; path = "../src/shared/assets/fonts/Pretendard-Regular.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */ = {isa = PBXFileReference; name = "Pretendard-SemiBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-SemiBold.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */ = {isa = PBXFileReference; name = "Pretendard-Thin.ttf"; path = "../src/shared/assets/fonts/Pretendard-Thin.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Thin.ttf"; path = "../src/shared/assets/fonts/Pretendard-Thin.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +78,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E16EA9A12D7815BF0056AA4B /* libRNKeychain.a in Frameworks */,
+				E1F801282D5DBBC600266514 /* libKakaoSDKAuth.a in Frameworks */,
+				E1F8012A2D5DBBC600266514 /* libKakaoSDKCommon.a in Frameworks */,
+				E1F8012C2D5DBBC600266514 /* libKakaoSDKUser.a in Frameworks */,
 				0C80B921A6F3F58F76C31292 /* libPods-nailian.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,6 +123,10 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */,
+				E1F801272D5DBBC600266514 /* libKakaoSDKAuth.a */,
+				E1F801292D5DBBC600266514 /* libKakaoSDKCommon.a */,
+				E1F8012B2D5DBBC600266514 /* libKakaoSDKUser.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-nailian.a */,
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-nailian-nailianTests.a */,
@@ -159,19 +166,8 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				3B4392A12AC88292D35C810B /* Pods-nailian.debug.xcconfig */,
-				5709B34CF0A7D63546082F79 /* Pods-nailian.release.xcconfig */,
-				5B7EB9410499542E8C5724F5 /* Pods-nailian-nailianTests.debug.xcconfig */,
-				89C6BE57DB24E9ADA2F236DE /* Pods-nailian-nailianTests.release.xcconfig */,
-			);
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		998E940FD9C74DE38B53EB79 /* Resources */ = {
-			isa = "PBXGroup";
+			isa = PBXGroup;
 			children = (
 				41B58996C11440A3B7EB6B13 /* Pretendard-Black.ttf */,
 				6B8B69C2F6D148E2A281ACF1 /* Pretendard-Bold.ttf */,
@@ -185,7 +181,17 @@
 			);
 			name = Resources;
 			sourceTree = "<group>";
-			path = "";
+		};
+		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3B4392A12AC88292D35C810B /* Pods-nailian.debug.xcconfig */,
+				5709B34CF0A7D63546082F79 /* Pods-nailian.release.xcconfig */,
+				5B7EB9410499542E8C5724F5 /* Pods-nailian-nailianTests.debug.xcconfig */,
+				89C6BE57DB24E9ADA2F236DE /* Pods-nailian-nailianTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
@@ -283,15 +289,6 @@
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				473BFEFAD123086068F6BFCD /* PrivacyInfo.xcprivacy in Resources */,
-				F9D6DEC360E54EF3BF27FC23 /* Pretendard-Black.ttf in Resources */,
-				428DD93CD3F643D999837A22 /* Pretendard-Bold.ttf in Resources */,
-				7C0698ED50BE4F1BBA05CEF7 /* Pretendard-ExtraBold.ttf in Resources */,
-				6BF40E32CB644B8D9B102545 /* Pretendard-ExtraLight.ttf in Resources */,
-				571A77FE07BA4527A7363332 /* Pretendard-Light.ttf in Resources */,
-				43B8ED3FBD0547FAA4A646D0 /* Pretendard-Medium.ttf in Resources */,
-				16E394A3DFE44FD398D9BBE7 /* Pretendard-Regular.ttf in Resources */,
-				4181259A48D84C55A6E820C9 /* Pretendard-SemiBold.ttf in Resources */,
-				F7EFBAC9D88F4B3486FC3C0D /* Pretendard-Thin.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -565,7 +562,7 @@
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -620,6 +617,7 @@
 					"\"$(SDKROOT)/usr/lib/swift\"",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
+					"$(SRCROOT)/../node_modules/@react-native-seoul/kakao-login/ios/**",
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -645,7 +643,7 @@
 		83CBBA211A601CBA00E9B192 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -693,6 +691,7 @@
 					"\"$(SDKROOT)/usr/lib/swift\"",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
+					"$(SRCROOT)/../node_modules/@react-native-seoul/kakao-login/ios/**",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/ios/nailian/Info.plist
+++ b/ios/nailian/Info.plist
@@ -44,20 +44,21 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
+	</array>@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>UIAppFonts</key>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_APP_KEY)</string>
+
+	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>Pretendard-Black.ttf</string>
-		<string>Pretendard-Bold.ttf</string>
-		<string>Pretendard-ExtraBold.ttf</string>
-		<string>Pretendard-ExtraLight.ttf</string>
-		<string>Pretendard-Light.ttf</string>
-		<string>Pretendard-Medium.ttf</string>
-		<string>Pretendard-Regular.ttf</string>
-		<string>Pretendard-SemiBold.ttf</string>
-		<string>Pretendard-Thin.ttf</string>
+		<string>kakao$(KAKAO_APP_KEY)</string>
+		<string>kakaolink</string>
+		<string>kakaokompassauth</string>
+	</array>
+	<key>KeychainAccessGroups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.nailian.app</string>
 	</array>
 </dict>
 </plist>

--- a/ios/nailian/PrivacyInfo.xcprivacy
+++ b/ios/nailian/PrivacyInfo.xcprivacy
@@ -6,10 +6,10 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
+				<string>35F9.1</string>
 			</array>
 		</dict>
 		<dict>
@@ -22,10 +22,10 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>35F9.1</string>
+				<string>C617.1</string>
 			</array>
 		</dict>
 	</array>

--- a/src/pages/nail_set/detail/index.tsx
+++ b/src/pages/nail_set/detail/index.tsx
@@ -22,10 +22,10 @@ import {
 } from '~/entities/nail-set/api';
 import BookmarkIcon from '~/shared/assets/icons/ic_group.svg';
 import TrashIcon from '~/shared/assets/icons/ic_trash.svg';
-import { useToast } from '~/shared/ui/Toast';
 import NailSet from '~/features/nail-set/ui/NailSet';
 import ArButton from '~/features/nail-set-ar/ui/ArButton';
 import Modal from '~/shared/ui/Modal';
+import { toast } from '~/shared/lib/toast';
 
 type NailSetDetailScreenRouteProp = RouteProp<
   RootStackParamList,
@@ -93,9 +93,6 @@ function NailSetDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [isBookmarked, setIsBookmarked] = useState(initialBookmarkState);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  // 하단 토스트 사용
-  const { showToast, ToastComponent } = useToast('bottom');
 
   // 유사한 네일 세트 목록 상태
   const [similarNailSets, setSimilarNailSets] = useState<INailSet[]>([]);
@@ -255,7 +252,7 @@ function NailSetDetailPage() {
         });
         // 성공적으로 저장되면 북마크 상태 업데이트 및 토스트 메시지 표시
         setIsBookmarked(true);
-        showToast('보관함에 저장되었습니다');
+        toast.showToast('보관함에 저장되었습니다');
         console.log(
           '네일 세트가 보관함에 성공적으로 저장되었습니다:',
           nailSetId,
@@ -265,14 +262,14 @@ function NailSetDetailPage() {
       console.error('Failed to save to bookmark', err);
       // 이미 저장된 네일인 경우 (HTTP 409 Conflict) 다른 메시지 표시
       if (err instanceof Error && err.message.includes('500')) {
-        showToast('이미 저장된 네일입니다');
+        toast.showToast('이미 저장된 네일입니다');
       } else {
-        showToast('보관함에 저장되었습니다');
+        toast.showToast('보관함에 저장되었습니다');
       }
       // API 오류 발생해도 북마크 상태는 true로 설정 (아이콘 숨김 처리)
       setIsBookmarked(true);
     }
-  }, [showToast, nailSet, nailSetId]);
+  }, [nailSet, nailSetId]);
 
   /**
    * 북마크 삭제 모달 표시 함수
@@ -299,17 +296,17 @@ function NailSetDetailPage() {
       if (!nailSetId) return;
       // 백엔드 API 구현 전까지는 콘솔 로그만 출력
       console.log('네일 세트 삭제:', nailSetId);
-      showToast('보관함에서 삭제되었습니다');
+      toast.showToast('보관함에서 삭제되었습니다');
       // 모달 닫기
       setShowDeleteModal(false);
       // 목록 화면으로 이동
       navigation.goBack();
     } catch (err) {
       console.error('보관함에서 삭제 실패:', err);
-      showToast('삭제 중 오류가 발생했습니다');
+      toast.showToast('삭제 중 오류가 발생했습니다');
       setShowDeleteModal(false);
     }
-  }, [nailSetId, navigation, showToast]);
+  }, [nailSetId, navigation]);
 
   /**
    * AR 기능 핸들러
@@ -472,9 +469,6 @@ function NailSetDetailPage() {
           onCancel={handleDeleteBookmark}
         />
       )}
-
-      {/* Toast 컴포넌트 */}
-      <ToastComponent />
     </SafeAreaView>
   );
 }

--- a/src/pages/onboarding/nail-select/index.tsx
+++ b/src/pages/onboarding/nail-select/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '~/entities/nail-preference/api';
 import { useOnboardingNavigation } from '~/features/onboarding/model/useOnboardingNavigation';
 import Button from '~/shared/ui/Button';
-import { useToast } from '~/shared/ui/Toast';
+import { toast } from '~/shared/lib/toast';
 
 /**
  * 온보딩 네일 선택 화면
@@ -47,9 +47,6 @@ export default function NailSelectScreen() {
   const [isEnabled, setIsEnabled] = useState(false); // 완료 버튼 활성화 상태
   const [isLoading, setIsLoading] = useState(false); // 추가 이미지 로딩 상태
   const [hasMore, setHasMore] = useState(true);
-
-  // 상단 토스트 사용
-  const { showToast, ToastComponent } = useToast('top');
 
   /**
    * 추가 네일 이미지 로드 함수
@@ -174,7 +171,7 @@ export default function NailSelectScreen() {
    * 상단에 안내 토스트 메시지를 표시합니다.
    */
   const handleSelectionLimit = () => {
-    showToast('최대 10개까지 선택할 수 있어요');
+    toast.showToast('최대 10개까지 선택할 수 있어요');
   };
 
   useEffect(() => {
@@ -231,9 +228,6 @@ export default function NailSelectScreen() {
       >
         <Text style={[styles.buttonText, typography.title2_SB]}>시작하기</Text>
       </Button>
-
-      {/* Toast 컴포넌트 교체 */}
-      <ToastComponent />
     </View>
   );
 }

--- a/src/pages/onboarding/nickname/index.tsx
+++ b/src/pages/onboarding/nickname/index.tsx
@@ -12,7 +12,7 @@ import { useOnboardingNavigation } from '~/features/onboarding/model/useOnboardi
 import { typography, colors } from '~/shared/styles/design';
 import Button from '~/shared/ui/Button';
 import ErrorIcon from '~/shared/assets/icons/ic_error.svg';
-import { useToast } from '~/shared/ui/Toast';
+import { toast } from '~/shared/lib/toast';
 
 /**
  * 온보딩 닉네임 입력 화면
@@ -29,7 +29,6 @@ export default function OnboardingNicknameScreen() {
   const [isError, setIsError] = useState(false);
   const { goToNextOnboardingStep } = useOnboardingNavigation();
   const [isKeyboardVisible, setKeyboardVisible] = useState(false);
-  const { showToast, ToastComponent } = useToast('top');
 
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener(
@@ -62,7 +61,7 @@ export default function OnboardingNicknameScreen() {
    * @param message 표시할 에러 메시지
    */
   const showErrorToast = (message: string) => {
-    showToast(message);
+    toast.showToast(message);
     setIsError(true);
   };
 
@@ -106,7 +105,6 @@ export default function OnboardingNicknameScreen() {
 
   return (
     <KeyboardAvoidingView style={styles.container} behavior="padding">
-      <ToastComponent />
       <View style={styles.content}>
         <View style={styles.titleContainer}>
           <Text style={styles.title}>반가워요!</Text>

--- a/src/shared/api/interceptors/auth.interceptor.ts
+++ b/src/shared/api/interceptors/auth.interceptor.ts
@@ -1,3 +1,4 @@
+import { toast } from '~/shared/lib/toast';
 import { RequestInterceptor, ResponseInterceptor } from '../types';
 import { reissueAccessToken } from '../../../entities/user/api';
 import { useAuthStore } from '../../store/authStore';
@@ -46,7 +47,7 @@ export const authRequestInterceptor: RequestInterceptor = async options => {
         // 리프레시 토큰도 만료된 경우 로그인 페이지로 이동
         await clearTokens();
         navigate('SocialLogin');
-        throw new Error('인증이 필요합니다.');
+        toast.showToast('로그인이 만료되었습니다. 다시 로그인해 주세요.');
       }
     }
   }
@@ -114,6 +115,7 @@ export const authResponseInterceptor: ResponseInterceptor = async response => {
       } catch (error) {
         onRefreshFailed();
         await clearTokens();
+        toast.showToast('로그인이 만료되었습니다. 다시 로그인해 주세요.');
         navigate('SocialLogin');
         return response;
       } finally {

--- a/src/shared/lib/toast.ts
+++ b/src/shared/lib/toast.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+type ToastPosition = 'top' | 'bottom';
+
+interface ToastOptions {
+  duration?: number;
+  position?: ToastPosition;
+}
+
+type ToastEvent = {
+  message: string;
+  options?: ToastOptions;
+};
+
+class ToastEmitter {
+  private static instance: ToastEmitter;
+
+  private listeners: ((event: ToastEvent) => void)[] = [];
+
+  static getInstance(): ToastEmitter {
+    if (!ToastEmitter.instance) {
+      ToastEmitter.instance = new ToastEmitter();
+    }
+    return ToastEmitter.instance;
+  }
+
+  showToast(message: string, options?: ToastOptions) {
+    this.listeners.forEach(listener => listener({ message, options }));
+  }
+
+  addListener(listener: (event: ToastEvent) => void) {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+}
+
+export const toast = ToastEmitter.getInstance();

--- a/src/shared/ui/Toast/index.tsx
+++ b/src/shared/ui/Toast/index.tsx
@@ -1,131 +1,8 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Text, StyleSheet, Animated } from 'react-native';
 import { colors, typography } from '~/shared/styles/design';
 import ErrorIcon from '~/shared/assets/icons/ic_error.svg';
-
-/**
- * 토스트 메시지 컴포넌트
- *
- * 사용자에게 일시적인 피드백을 제공하는 알림 메시지입니다.
- * 상단과 하단에 표시 가능하며, 자동으로 사라지는 애니메이션이 포함되어 있습니다.
- *
- * @example
- * // 상단 토스트
- * <Toast
- *   message="최대 10개까지 선택할 수 있어요"
- *   visible={showToast}
- *   position="top"
- * />
- *
- * // 하단 토스트
- * <Toast
- *   message="저장되었습니다"
- *   visible={showToast}
- *   position="bottom"
- * />
- */
-type ToastPosition = 'top' | 'bottom';
-
-/**
- * Toast 컴포넌트의 속성을 정의하는 인터페이스
- */
-interface ToastProps {
-  /** 표시할 메시지 내용 */
-  message: string;
-  /** 토스트 표시 여부 */
-  visible: boolean;
-  /** 토스트 위치 (기본값: top) */
-  position?: ToastPosition;
-}
-
-/**
- * Toast 옵션 인터페이스
- */
-interface ToastOptions {
-  /** 토스트가 표시되는 지속 시간 (밀리초 단위, 기본값: 3000ms) */
-  duration?: number;
-  /** 토스트의 위치 ('top' 또는 'bottom') */
-  position?: ToastPosition;
-}
-
-/**
- * useToast 훅의 반환 타입 인터페이스
- */
-interface UseToastReturn {
-  /** 토스트를 표시하는 함수 */
-  showToast: (msg: string, options?: ToastOptions) => void;
-  /** 토스트의 표시 여부 */
-  visible: boolean;
-  /** 현재 표시 중인 토스트 메시지 */
-  message: string;
-  /** 현재 토스트의 위치 */
-  position: ToastPosition;
-  /** 렌더링할 토스트 컴포넌트 */
-  ToastComponent: () => JSX.Element;
-}
-
-/**
- * useToast 훅 - Toast 메시지를 표시하기 위한 커스텀 훅
- *
- * 앱 내에서 일관된 방식으로 토스트 메시지를 표시할 수 있게 해주는 커스텀 훅입니다.
- * 상단 또는 하단에 토스트를 표시할 수 있으며, 메시지와 지속 시간을 설정할 수 있습니다.
- *
- * @param defaultPosition 토스트의 기본 위치 (기본값: 'top')
- * @returns {UseToastReturn} 토스트 관련 상태와 함수들을 포함한 객체
- *
- * @example
- * // 상단 토스트 사용
- * const { showToast, ToastComponent } = useToast('top');
- *
- * // 토스트 표시
- * showToast('메시지 내용');
- *
- * // 하단 토스트로 지속 시간 설정
- * showToast('저장되었습니다', { position: 'bottom', duration: 2000 });
- *
- * // 컴포넌트에 추가
- * return (
- *   <View>
- *     컴포넌트들
- *     <ToastComponent />
- *   </View>
- * );
- */
-export function useToast(
-  defaultPosition: ToastPosition = 'top',
-): UseToastReturn {
-  const [visible, setVisible] = useState(false);
-  const [message, setMessage] = useState('');
-  const [position, setPosition] = useState<ToastPosition>(defaultPosition);
-
-  const showToast = useCallback((msg: string, options?: ToastOptions) => {
-    const { duration = 3000, position: toastPosition } = options || {};
-
-    setMessage(msg);
-    if (toastPosition) {
-      setPosition(toastPosition);
-    }
-    setVisible(true);
-
-    // 지정된 시간 후 토스트 숨기기
-    setTimeout(() => {
-      setVisible(false);
-    }, duration);
-  }, []);
-
-  const ToastComponent = useCallback(
-    () => <Toast visible={visible} message={message} position={position} />,
-    [visible, message, position],
-  );
-
-  return {
-    showToast,
-    visible,
-    message,
-    position,
-    ToastComponent,
-  };
-}
+import { toast } from '~/shared/lib/toast';
 
 /**
  * Toast 컴포넌트 - 사용자에게 일시적인 알림 메시지를 표시합니다.
@@ -136,15 +13,49 @@ export function useToast(
  * @param {ToastProps} props Toast 컴포넌트 속성
  * @returns {JSX.Element | null} 토스트 컴포넌트 또는 표시되지 않을 경우 null
  */
-export default function Toast({
-  message,
-  visible,
-  position = 'top',
-}: ToastProps) {
+export function ToastContainer() {
+  const [visible, setVisible] = useState(false);
+  const [message, setMessage] = useState('');
+  const [position, setPosition] = useState<'top' | 'bottom'>('top');
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const fadeAnim = useRef(new Animated.Value(0)).current;
-  const translateY = useRef(
-    new Animated.Value(position === 'top' ? -20 : 20),
-  ).current;
+  const translateY = useRef(new Animated.Value(0)).current;
+
+  const showToastMessage = useCallback(
+    (newMessage: string, toastPosition: 'top' | 'bottom', duration: number) => {
+      // 이전 타이머가 있다면 클리어
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      setMessage(newMessage);
+      setPosition(toastPosition);
+      setVisible(true);
+
+      // 새로운 타이머 설정
+      timeoutRef.current = setTimeout(() => {
+        setVisible(false);
+      }, duration);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const unsubscribe = toast.addListener(({ message, options }) => {
+      const { duration = 3000, position: toastPosition = 'top' } =
+        options || {};
+      showToastMessage(message, toastPosition, duration);
+    });
+
+    // cleanup
+    return () => {
+      unsubscribe();
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [showToastMessage]);
 
   useEffect(() => {
     // 진행 중인 애니메이션 중지


### PR DESCRIPTION
### 🔖 관련 티켓
SN-68 ([Jira 링크](https://crusia.atlassian.net/browse/SN-68))

### 📌 작업 개요 
기존 토스트 메시지 방식을 이벤트 이미터 방식으로 변경
### ✅ 작업 항목 
- 기존 useToast 훅 삭제
- 이벤트 기반 토스트 시스템 추가
- 기존 토스트 코드 변경
- Interceptor.ts에 토스트 메세지 추가


### 📝 추가 설명

기존 토스트 방식을 좀 더 중앙 집중화 하기 위해, .ts 파일에서도 사용하기 위해 이벤트 방식으로 변경하였습니다.