### PR TITLE
[FIX] pagination 응답 형식 변경

### DIFF
--- a/src/entities/nail-tip/api.ts
+++ b/src/entities/nail-tip/api.ts
@@ -19,7 +19,7 @@ export const fetchNails = async (
   };
 
   return fetcher({
-    endpoint: '/nails', // 네일 목록 조회 API 엔드포인트
+    endpoint: '/nails/', // 네일 목록 조회 API 엔드포인트
     query,
   });
 };

--- a/src/mocks/utils/pagination.ts
+++ b/src/mocks/utils/pagination.ts
@@ -11,7 +11,7 @@
  *     totalPages: number;
  *     totalElements: number;
  *   };
- *   data: T[];
+ *   content: T[];
  * }} 페이지네이션이 적용된 데이터
  */
 const createPaginatedResponse = <T>(items: T[], page: number, size: number) => {
@@ -32,7 +32,7 @@ const createPaginatedResponse = <T>(items: T[], page: number, size: number) => {
       totalPages,
       totalElements,
     },
-    data: paginatedItems,
+    content: paginatedItems,
   };
 };
 

--- a/src/pages/nail_set/detail/index.tsx
+++ b/src/pages/nail_set/detail/index.tsx
@@ -153,13 +153,13 @@ function NailSetDetailPage() {
           let data, pageInfo;
           if (isBookmarkMode) {
             // 북마크 모드일 때 응답 처리
-            data = response.data.data || [];
+            data = response.data.content || [];
             pageInfo = response.data.pageInfo;
             // 현재 보고 있는 네일 세트는 제외
             data = data.filter((item: INailSet) => item.id !== nailSetId);
           } else {
             // 일반 모드일 때 응답 처리
-            data = response.data.data || [];
+            data = response.data.content || [];
             pageInfo = response.data.pageInfo;
           }
 

--- a/src/pages/nail_set/list/index.tsx
+++ b/src/pages/nail_set/list/index.tsx
@@ -96,7 +96,7 @@ function NailSetListPage() {
 
         if (response.data) {
           // 페이지네이션 응답에서 데이터 배열 추출
-          const newNailSets = response.data.data || [];
+          const newNailSets = response.data.content || [];
 
           // 데이터 설정 (초기화 또는 추가)
           if (reset) {
@@ -137,8 +137,8 @@ function NailSetListPage() {
 
     try {
       const response = await fetchUserNailSets({ page: 1, size: 100 });
-      if (response.data?.data) {
-        setBookmarkedNailIds(response.data.data.map(item => item.id));
+      if (response.data?.content) {
+        setBookmarkedNailIds(response.data.content.map(item => item.id));
       }
     } catch (err) {
       console.error('북마크 상태 불러오기 실패:', err);

--- a/src/pages/onboarding/nail-select/index.tsx
+++ b/src/pages/onboarding/nail-select/index.tsx
@@ -64,7 +64,7 @@ export default function NailSelectScreen() {
         });
         if (response.data) {
           const newData =
-            response.data?.data.map(nail => ({
+            response.data?.content.map(nail => ({
               ...nail,
               id: String(nail.id), // id를 String으로 변환
             })) ?? [];

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -20,7 +20,7 @@ export interface PaginatedResponse<T> {
     totalElements: number;
     totalPages: number;
   };
-  data: T[];
+  content: T[];
 }
 
 /* ─────────────────── 사용자 (Users) ─────────────────── */


### PR DESCRIPTION
### 🔖 관련 티켓
SN-71 ([Jira 링크](https://crusia.atlassian.net/browse/SN-71))
### 📌 작업 개요 
fix: update API response field to match backend spec (response.data.data → response.data.content)
### ✅ 작업 항목 
페이지네이션 응답 타입이 data로 되어있어 response의 기본 응답 형식인 data와 혼동이 됩니다.
또한, 기존에 스웨거 및 백엔드 구현 상 페이지네이션 응답이 content와 pageInfo로 오기 때문에
백엔드와의 api 연동 과정 간 프론트엔드 타입 및 컴포넌트 코드를 data에서 content로 변경합니다.


### 📝 추가 설명
