### PR TITLE
[FIX] 카카오 로그인 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,6 @@ src/mocks/data/*
 .env
 .env.* 
 
-# iOS 보안 파일
-ios/nailian/Secrets.plist
-ios/Config.xcconfig 
+# iOS security files
+ios/Debug.xcconfig
+ios/Release.xcconfig

--- a/ios/nailian/AppDelegate.mm
+++ b/ios/nailian/AppDelegate.mm
@@ -1,5 +1,5 @@
 #import "AppDelegate.h"
-
+#import <RNKakaoLogins.h>
 #import <React/RCTBundleURLProvider.h>
 
 @implementation AppDelegate
@@ -12,6 +12,16 @@
   self.initialProps = @{};
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+// URL 처리를 위한 메서드
+- (BOOL)application:(UIApplication *)app
+     openURL:(NSURL *)url
+     options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+ if([RNKakaoLogins isKakaoTalkLoginUrl:url]) {
+    return [RNKakaoLogins handleOpenUrl: url];
+ }
+ return NO;
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/ios/nailian/Info.plist
+++ b/ios/nailian/Info.plist
@@ -47,12 +47,20 @@
 	<false/>
 	<key>KAKAO_APP_KEY</key>
 	<string>$(KAKAO_APP_KEY)</string>
-
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakao$(KAKAO_APP_KEY)</string>
 		<string>kakaolink</string>
 		<string>kakaokompassauth</string>
+	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_APP_KEY)</string>
+			</array>
+		</dict>
 	</array>
 	<key>KeychainAccessGroups</key>
 	<array>


### PR DESCRIPTION
### 🔖 관련 티켓
SN-82 ([Jira 링크](https://crusia.atlassian.net/browse/SN-82))

### 📌 작업 개요 
카카오 로그인에 관한 iOS 설정 수정
### ✅ 작업 항목 
-  info.plist에 CFBundleURLTypes추가
- AppDelegate에 URL 처리를 위한 메서드 추가
- IOS 키값 관리 보안 파일 변경


### 📝 추가 설명

.xcconfig는 개인적으로 전달드리겠습니다