### PR TITLE
[FEAT] 어플 실행시 모델 자동 로드

### DIFF
--- a/ios/Modules/ModelManager.swift
+++ b/ios/Modules/ModelManager.swift
@@ -142,7 +142,7 @@ class ModelManager: RCTEventEmitter {
                     var segmentationSuccess = false
                     
                     DispatchQueue.global(qos: .background).async {
-                        SegmentationManager.shared.preloadModel { result in
+                        SegmentationManager.shared.loadSegmentationModel { result in
                             segmentationSuccess = result
                             semaphore.signal()
                         }

--- a/ios/Modules/ModelManager.swift
+++ b/ios/Modules/ModelManager.swift
@@ -135,6 +135,22 @@ class ModelManager: RCTEventEmitter {
                 try FileManager.default.moveItem(at: tempLocalUrl, to: zipFilePath)
                 try self.extractModel(zipFilePath: zipFilePath, modelType: modelType)
                 try FileManager.default.removeItem(at: zipFilePath)
+                
+                // 모델 프리로드
+                if modelType == "segmentation" {
+                    let semaphore = DispatchSemaphore(value: 0)
+                    var segmentationSuccess = false
+                    
+                    DispatchQueue.global(qos: .background).async {
+                        SegmentationManager.shared.preloadModel { result in
+                            segmentationSuccess = result
+                            semaphore.signal()
+                        }
+                    }
+                    
+                    _ = semaphore.wait(timeout: .now() + 30.0)
+                }
+                
                 self.sendEvent(withName: "ModelDownloadComplete", body: ["modelType": modelType, "success": true])
                 resolver(true)
             } catch {

--- a/ios/Modules/SegmentationManager.swift
+++ b/ios/Modules/SegmentationManager.swift
@@ -71,7 +71,7 @@ import Accelerate
       }
       
       // 모델 미리 로드
-      private func preloadModel() {
+      func preloadModel(completion: ((Bool) -> Void)? = nil) {
           DispatchQueue.global(qos: .background).async {
               do {
                   let config = MLModelConfiguration()
@@ -80,6 +80,7 @@ import Accelerate
                   // 로컬에 모델 파일이 있는지 확인
                   guard let modelURL = self.localModelURL() else {
                       self.modelLoaded = false
+                      completion?(false)
                       return
                   }
                   
@@ -88,9 +89,10 @@ import Accelerate
                   
                   self.model = try MLModel(contentsOf: compiledModelURL, configuration: config)
                   self.modelLoaded = true
+                  completion?(true)
               } catch {
                   self.modelLoaded = false
-                  print("모델 로드 실패: \(error.localizedDescription)")
+                  completion?(false)
               }
           }
       }

--- a/ios/Modules/SegmentationManager.swift
+++ b/ios/Modules/SegmentationManager.swift
@@ -71,7 +71,7 @@ import Accelerate
       }
       
       // 모델 미리 로드
-      func preloadModel(completion: ((Bool) -> Void)? = nil) {
+      func loadSegmentationModel(completion: ((Bool) -> Void)? = nil) {
           DispatchQueue.global(qos: .background).async {
               do {
                   let config = MLModelConfiguration()

--- a/ios/Modules/SegmentationManager.swift
+++ b/ios/Modules/SegmentationManager.swift
@@ -19,7 +19,6 @@ import Accelerate
 
     private override init() {
         super.init()
-        preloadModel()
     }
     
   // 로컬에 다운로드된 모델 URL 확인


### PR DESCRIPTION
### 🔖 관련 티켓
SN-110 ([Jira 링크](https://crusia.atlassian.net/browse/SN-110))

### 📌 작업 개요 
AR 체험 기능 진입 시 발생하던 모델 로딩 지연을 해소하기 위해,
앱 실행 시점에 모델을 선제적으로 컴파일 및 메모리 로드하도록 변경하였습니다.

### ✅ 작업 항목 
- 기존 SegmentaionManager Init시 preload 삭제
- 어플 실행시로 모델 로드 시점 변경


### 📝 추가 설명

메모리에 계속 모델을 안고가야하는 부담이 있지만, 첫 AR 체험하기 시 모델 로드의 딜레이가 너무 크며
현재 세그먼테이션 모델의 용량이 7mb 가량인 점을 고려하여 어플 실행시 선제 로드하는 방법을 선택했습니다.
추후 모델의 용량이 더 커진다면 다시 방법을 생각해봐야할것 같습니다.