### PR TITLE
[FEAT] (SQ-19 대응) GET /nails/ random 쿼리 파라미터 추가

### DIFF
--- a/src/entities/nail-tip/api.ts
+++ b/src/entities/nail-tip/api.ts
@@ -14,6 +14,7 @@ export const fetchNails = async (
     ...(params.color && { color: params.color }), // 색상 필터
     ...(params.shape && { shape: params.shape }), // 모양 필터
     ...(params.category && { category: params.category }), // 카테고리 필터
+    ...(params.random && { random: params.random }), // 랜덤 필터
     page: params.page, // 페이지 번호
     size: params.size, // 페이지 크기
   };

--- a/src/pages/ar_experience/ui/NailGrid/index.tsx
+++ b/src/pages/ar_experience/ui/NailGrid/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   View,
   StyleSheet,
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { colors } from '~/shared/styles/design';
-import { NailListResponse, Shape } from '~/shared/api/types';
+import { Shape } from '~/shared/api/types';
 import { fetchNails } from '~/entities/nail-tip/api';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { scale, vs } from '~/shared/lib/responsive';

--- a/src/pages/ar_experience/ui/NailGrid/index.tsx
+++ b/src/pages/ar_experience/ui/NailGrid/index.tsx
@@ -99,6 +99,7 @@ export function NailGrid({
         category: activeFilters.category,
         color: activeFilters.color,
         shape: activeFilters.shape,
+        random: activeFilters ? 1 : 0,
       }),
     getNextPageParam: lastPage => {
       const totalPages = lastPage.data?.pageInfo?.totalPages || 0;

--- a/src/pages/onboarding/nail-select/index.tsx
+++ b/src/pages/onboarding/nail-select/index.tsx
@@ -68,6 +68,7 @@ export default function NailSelectScreen() {
         fetchNails({
           page: pageParam,
           size: 20,
+          random: 1,
         }),
       getNextPageParam: lastPage => {
         const totalPages = lastPage.data?.pageInfo?.totalPages || 0;

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -120,9 +120,10 @@ export type Shape = 'SQUARE' | 'ROUND' | 'ALMOND' | 'BALLERINA' | 'STILETTO';
 
 /** 네일 목록 조회 요청 */
 export interface GetNailsRequest extends PaginationRequest {
-  color?: string;
-  shape?: string;
-  category?: string;
+  color?: Color;
+  shape?: Shape;
+  category?: Category;
+  random?: number;
 }
 
 /** 네일 목록 조회 응답 */


### PR DESCRIPTION
### 🔖 관련 티켓
SN-126 ([Jira 링크](https://crusia.atlassian.net/browse/SN-126))

### 📌 작업 개요 
/nails/의 default random boolean 값이 false가 됨에 따라
필터 modal을 제외한 곳에서는 random을 사용하도록 수정하겠습니다.
### ✅ 작업 항목 
- /nails/ GET 타입에 random 추가.
- 필터 modal을 제외한 Onboarding nail-selection 및 ar-exp.에서 random=true 부여.
- 기존 filter 파라미터 타입이 string으로 되어 있어, 정해진 enum 값으로 변경.


### 📝 추가 설명