### PR TITLE
[FEAT] AR 체험 페이지로 네일 세트 정보 전달 (SQ-12)

### DIFF
--- a/src/app/providers/navigation.tsx
+++ b/src/app/providers/navigation.tsx
@@ -17,6 +17,7 @@ import NailSetListPage from '~/pages/nail_set/list';
 import NailSetDetailPage from '~/pages/nail_set/detail';
 import ARExperiencePage from '~/pages/ar_experience';
 import ARCameraPage from '~/pages/ar_camera';
+import ARViewPage from '~/pages/ar_experience/ui/ViewMode';
 import ErrorBoundary from '~/pages/error';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -90,6 +91,10 @@ export default function AppNavigation() {
         <Stack.Screen
           name="ARCameraPage"
           component={withErrorBoundary(ARCameraPage)}
+        />
+        <Stack.Screen
+          name="ARViewPage"
+          component={withErrorBoundary(ARViewPage)}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/pages/ar_experience/ui/NailGrid/index.tsx
+++ b/src/pages/ar_experience/ui/NailGrid/index.tsx
@@ -40,7 +40,14 @@ interface NailGridProps {
    * 손가락 타입과 인덱스 매핑
    */
   fingerMap: Array<{ index: number; type: string }>;
+  /**
+   * 필터 초기화 콜백
+   */
   onResetFilter?: () => void;
+  /**
+   * 읽기 전용 모드 (뷰 모드에서 사용)
+   */
+  readOnly?: boolean;
 }
 
 // 네일셋 변경 시 전달되는 임시 타입
@@ -71,6 +78,7 @@ export function NailGrid({
   isSelectingImage = false,
   fingerMap,
   onResetFilter,
+  readOnly = false,
 }: NailGridProps) {
   const scrollViewRef =
     useRef<React.ComponentRef<typeof BottomSheetScrollView>>(null);
@@ -149,11 +157,13 @@ export function NailGrid({
   // 그리드 네일 아이템 클릭 핸들러
   const handleNailItemClick = useCallback(
     (item: { id: number; imageUrl: string; shape?: Shape }) => {
+      // 읽기 전용 모드에서는 동작하지 않음
+      if (readOnly) return;
       if (isSelectingImage && selectedNailButton !== null) {
         addImageToNailSet(selectedNailButton, item);
       }
     },
-    [isSelectingImage, selectedNailButton, addImageToNailSet],
+    [isSelectingImage, selectedNailButton, addImageToNailSet, readOnly],
   );
 
   // 네일 아이템 렌더링 함수

--- a/src/pages/ar_experience/ui/NailSelection/index.tsx
+++ b/src/pages/ar_experience/ui/NailSelection/index.tsx
@@ -34,6 +34,10 @@ interface NailSelectionProps {
    * 네일셋 변경 핸들러
    */
   onNailSetChange: (nailSet: NailSet) => void;
+  /**
+   * 읽기 전용 모드 (뷰 모드에서 사용)
+   */
+  readOnly?: boolean;
 }
 // 네일셋 변경 시 전달되는 임시 타입
 interface NailSetUpdate extends Partial<NailSet> {
@@ -60,6 +64,7 @@ interface NailSetUpdate extends Partial<NailSet> {
 export default function NailSelection({
   currentNailSet,
   onNailSetChange,
+  readOnly = false,
 }: NailSelectionProps) {
   // 필터 모달 상태
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
@@ -95,6 +100,9 @@ export default function NailSelection({
   // 손가락 버튼 클릭 핸들러
   const handleNailButtonClick = useCallback(
     (index: number) => {
+      // 읽기 전용 모드에서는 동작하지 않음
+      if (readOnly) return;
+
       // 이미 선택된 버튼이면 선택 해제
       if (selectedNailButton === index) {
         setSelectedNailButton(null);
@@ -106,12 +114,15 @@ export default function NailSelection({
       setSelectedNailButton(index);
       setIsSelectingImage(true);
     },
-    [selectedNailButton],
+    [selectedNailButton, readOnly],
   );
 
   // 네일 이미지 삭제 핸들러
   const handleNailImageDelete = useCallback(
     (index: number) => {
+      // 읽기 전용 모드에서는 동작하지 않음
+      if (readOnly) return;
+
       const fingerType =
         (FINGER_MAP.find(item => item.index === index)
           ?.type as keyof NailSet) || 'pinky';
@@ -123,7 +134,7 @@ export default function NailSelection({
 
       setSelectedNailButton(null);
     },
-    [currentNailSet, onNailSetChange],
+    [currentNailSet, onNailSetChange, readOnly],
   );
 
   // 네일셋 변경 핸들러
@@ -193,26 +204,28 @@ export default function NailSelection({
         {/* 네일 추가 버튼 영역 */}
         <View style={styles.nailButtonsContainer}>{renderNailButtons()}</View>
 
-        {/* 필터 버튼 */}
-        <View style={styles.filterContainer}>
-          <TouchableOpacity
-            style={styles.filterButton}
-            onPress={handleFilterClick}
-            activeOpacity={1}
-          >
-            <View style={styles.filterButtonContent}>
-              <FilterIcon
-                width={scale(20)}
-                height={scale(20)}
-                color={colors.gray600}
-              />
-              <Text style={styles.filterText}>필터</Text>
-              {Object.keys(activeFilters).length > 0 && (
-                <View style={styles.filterActiveIndicator} />
-              )}
-            </View>
-          </TouchableOpacity>
-        </View>
+        {/* 필터 버튼 - 읽기 전용 모드에서는 표시하지 않음 */}
+        {!readOnly && (
+          <View style={styles.filterContainer}>
+            <TouchableOpacity
+              style={styles.filterButton}
+              onPress={handleFilterClick}
+              activeOpacity={1}
+            >
+              <View style={styles.filterButtonContent}>
+                <FilterIcon
+                  width={scale(20)}
+                  height={scale(20)}
+                  color={colors.gray600}
+                />
+                <Text style={styles.filterText}>필터</Text>
+                {Object.keys(activeFilters).length > 0 && (
+                  <View style={styles.filterActiveIndicator} />
+                )}
+              </View>
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
 
       {/* 그래디언트 이미지 */}
@@ -230,6 +243,7 @@ export default function NailSelection({
           selectedNailButton={selectedNailButton}
           isSelectingImage={isSelectingImage}
           fingerMap={FINGER_MAP}
+          readOnly={readOnly}
         />
       </View>
 

--- a/src/pages/ar_experience/ui/ViewMode/index.tsx
+++ b/src/pages/ar_experience/ui/ViewMode/index.tsx
@@ -1,0 +1,307 @@
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StatusBar,
+  Image,
+  BackHandler,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+} from 'react-native';
+import BottomSheet, {
+  BottomSheetRefProps,
+} from '~/pages/ar_experience/ui/BottomSheet';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import NailOverlay from '~/pages/ar_experience/ui/NailOverlay';
+import { TabBarHeader } from '~/shared/ui/TabBar';
+import ArButton from '~/features/nail-set-ar/ui/ArButton';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { Shape } from '~/shared/api/types';
+import { RootStackParamList } from '~/shared/types/navigation';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { INailSet } from '~/shared/types/nail-set';
+import { colors, typography } from '~/shared/styles/design';
+import { scale, vs } from '~/shared/lib/responsive';
+import NailSelection from '../NailSelection';
+
+// 손가락 타입 정의
+export type FingerType = 'pinky' | 'ring' | 'middle' | 'index' | 'thumb';
+
+// 손가락 타입 상수
+export const FINGER_TYPES = [
+  'thumb',
+  'index',
+  'middle',
+  'ring',
+  'pinky',
+] as const;
+
+/**
+ * 네일 세트 인터페이스 (API 요청 형식에 맞춤)
+ */
+export interface NailSet {
+  thumb?: { id: number; imageUrl: string; shape?: Shape };
+  index?: { id: number; imageUrl: string; shape?: Shape };
+  middle?: { id: number; imageUrl: string; shape?: Shape };
+  ring?: { id: number; imageUrl: string; shape?: Shape };
+  pinky?: { id: number; imageUrl: string; shape?: Shape };
+}
+
+/**
+ * AR 뷰 페이지
+ *
+ * 네일 세트 상세 페이지에서 전달받은 네일 세트를 AR로 보여주는 화면입니다.
+ * 사용자는 네일 세트를 수정할 수 없고 볼 수만 있습니다.
+ *
+ * @returns {JSX.Element} AR 뷰 페이지 컴포넌트
+ */
+export default function ARViewPage() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'ARViewPage'>>();
+
+  // 바텀시트 참조 생성
+  const bottomSheetRef = useRef<BottomSheetRefProps>(null);
+  // 현재 바텀시트 인덱스 상태
+  const [bottomSheetIndex, setBottomSheetIndex] = useState(0);
+
+  // INailSet을 NailSet으로 변환
+  const convertToNailSet = (nailSet: INailSet): NailSet => ({
+    thumb: nailSet.thumb
+      ? {
+          id: -1, // INail에는 id가 없으므로 -1로 설정
+          imageUrl: nailSet.thumb.imageUrl,
+          shape: nailSet.thumb.shape,
+        }
+      : undefined,
+    index: nailSet.index
+      ? {
+          id: -1,
+          imageUrl: nailSet.index.imageUrl,
+          shape: nailSet.index.shape,
+        }
+      : undefined,
+    middle: nailSet.middle
+      ? {
+          id: -1,
+          imageUrl: nailSet.middle.imageUrl,
+          shape: nailSet.middle.shape,
+        }
+      : undefined,
+    ring: nailSet.ring
+      ? {
+          id: -1,
+          imageUrl: nailSet.ring.imageUrl,
+          shape: nailSet.ring.shape,
+        }
+      : undefined,
+    pinky: nailSet.pinky
+      ? {
+          id: -1,
+          imageUrl: nailSet.pinky.imageUrl,
+          shape: nailSet.pinky.shape,
+        }
+      : undefined,
+  });
+
+  // route.params에서 전달받은 네일 세트를 NailSet 타입으로 변환
+  const [currentNailSet] = useState<NailSet>(
+    convertToNailSet(route.params.nailSet),
+  );
+
+  /**
+   * AR 버튼 클릭 핸들러
+   */
+  const handleArButtonPress = useCallback(() => {
+    navigation.navigate('ARCameraPage');
+  }, [navigation]);
+
+  /**
+   * 뒤로가기 버튼 핸들러
+   * 사용자가 뒤로가기 버튼을 클릭했을 때 이전 화면으로 돌아갑니다.
+   */
+  const handleGoBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  /**
+   * 바텀시트 인덱스 변경 핸들러
+   * 바텀시트의 위치가 변경되었을 때 호출됩니다.
+   *
+   * @param {number} index - 변경된 바텀시트 인덱스
+   */
+  const handleSheetChange = useCallback((index: number) => {
+    setBottomSheetIndex(index);
+  }, []);
+
+  /**
+   * Android 뒤로가기 버튼 제어
+   * Android에서 물리적 뒤로가기 버튼을 눌렀을 때의 동작을 처리합니다.
+   */
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        if (bottomSheetIndex !== 0) {
+          bottomSheetRef.current?.snapToIndex(0);
+          return true; // 이벤트 처리 완료
+        }
+        return false; // 기본 뒤로가기 동작 수행
+      },
+    );
+
+    return () => backHandler.remove();
+  }, [bottomSheetIndex]); // 의존성 배열에 bottomSheetIndex 포함
+
+  // 바텀시트 커스텀 핸들 컴포넌트
+  const renderCustomHandle = (
+    <View style={styles.header}>
+      <View style={styles.indicator} />
+    </View>
+  );
+
+  return (
+    <BottomSheetModalProvider>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.container}>
+          <StatusBar barStyle="dark-content" />
+
+          {/* 상단 탭바 */}
+          <TabBarHeader title="" onBack={handleGoBack} rightContent={null} />
+
+          {/* 메인 콘텐츠 영역 */}
+          <View style={styles.contentArea}>
+            {/* 상단 타이틀 */}
+            <View style={styles.titleContainer}>
+              <Text style={styles.mainTitle}>네일 아트를 확인해보세요</Text>
+              <Text style={styles.subTitle}>
+                AR로 실제 손에 적용해볼 수 있어요
+              </Text>
+            </View>
+
+            {/* 손 이미지와 네일 오버레이 컨테이너 */}
+            <View style={styles.handContainer}>
+              {/* 기본 손 이미지 */}
+              <Image
+                source={require('~/shared/assets/images/hand.png')}
+                style={styles.handImage}
+                resizeMode="contain"
+              />
+
+              {/* 네일 오버레이 - 선택된 네일팁을 손 위에 표시 */}
+              <NailOverlay nailSet={currentNailSet} />
+            </View>
+
+            {/* AR 버튼 */}
+            <View style={styles.arButtonContainer}>
+              <ArButton onPress={handleArButtonPress} />
+            </View>
+          </View>
+
+          {/* 바텀시트 */}
+          <BottomSheet
+            ref={bottomSheetRef}
+            snapPoints={['20%']}
+            initialIndex={0}
+            handleType="custom"
+            customHandle={renderCustomHandle}
+            onChange={handleSheetChange}
+            backgroundStyle={styles.bottomSheetBackground}
+            contentContainerStyle={styles.contentContainer}
+            enablePanDownToClose={false}
+            enableContentPanningGesture={false}
+            enableHandlePanningGesture={false}
+          >
+            <NailSelection
+              currentNailSet={currentNailSet}
+              onNailSetChange={() => {}}
+              readOnly={true}
+            />
+          </BottomSheet>
+        </View>
+      </SafeAreaView>
+    </BottomSheetModalProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  arButtonContainer: {
+    alignItems: 'center',
+    marginTop: vs(18),
+  },
+  bottomSheetBackground: {
+    backgroundColor: colors.white,
+    borderColor: colors.black,
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
+    borderTopWidth: 30,
+    // iOS의 안전 영역 고려
+    paddingBottom: Platform.OS === 'ios' ? vs(34) : 0,
+  },
+  container: {
+    backgroundColor: colors.white,
+    flex: 1,
+  },
+  contentArea: {
+    backgroundColor: colors.white,
+    flex: 1,
+    paddingTop: vs(8),
+  },
+  contentContainer: {
+    flex: 1,
+    paddingHorizontal: 0,
+    paddingTop: vs(10),
+  },
+  handContainer: {
+    alignItems: 'center',
+    height: vs(370),
+    marginTop: vs(24),
+    position: 'relative',
+  },
+  handImage: {
+    height: vs(370),
+    width: scale(237),
+  },
+  header: {
+    alignItems: 'center',
+    backgroundColor: colors.white,
+    borderLeftColor: colors.gray100,
+    borderLeftWidth: 1,
+    borderRightColor: colors.gray100,
+    borderRightWidth: 1,
+    borderTopColor: colors.gray100,
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
+    borderTopWidth: 1,
+    elevation: 0,
+    paddingVertical: vs(15),
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0,
+    shadowRadius: 0,
+  },
+  indicator: {
+    backgroundColor: colors.gray200,
+    borderRadius: 100,
+    height: vs(4),
+    width: scale(44),
+  },
+  mainTitle: {
+    ...typography.head2_B,
+    color: colors.gray850,
+  },
+  safeArea: {
+    backgroundColor: colors.white,
+    flex: 1,
+  },
+  subTitle: {
+    ...typography.body4_M,
+    color: colors.gray500,
+    marginTop: vs(4),
+  },
+  titleContainer: {
+    marginLeft: scale(22),
+  },
+});

--- a/src/pages/nail_set/detail/index.tsx
+++ b/src/pages/nail_set/detail/index.tsx
@@ -200,8 +200,16 @@ function NailSetDetailPage() {
   }, [nailSetId, deleteBookmark]);
 
   const handleArButtonPress = useCallback(() => {
-    navigation.navigate('ARExperiencePage');
-  }, [navigation]);
+    // 이미 로드된 네일 세트 데이터가 있으므로 이를 활용하여 AR 뷰 페이지로 이동
+    if (nailSet?.data) {
+      navigation.navigate('ARViewPage', { nailSet: nailSet.data });
+    } else {
+      // 데이터가 없는 경우 토스트 메시지 표시
+      toast.showToast('네일 정보를 불러오는데 실패했습니다', {
+        position: 'bottom',
+      });
+    }
+  }, [navigation, nailSet]);
 
   // 스크롤 이벤트 처리를 위한 상태
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(false);

--- a/src/shared/types/navigation.ts
+++ b/src/shared/types/navigation.ts
@@ -1,3 +1,4 @@
+import { INailSet } from './nail-set';
 /**
  * 루트 네비게이션 스택의 파라미터 타입 정의
  *
@@ -49,8 +50,13 @@ export type RootStackParamList = {
     isBookmarked?: boolean;
   };
 
-  /** AR 체험 페이지 */
+  /** AR 체험 페이지 - 일반 편집 모드 */
   ARExperiencePage: undefined;
+
+  /** AR 체험 페이지 - 뷰 전용 모드 */
+  ARViewPage: {
+    nailSet: INailSet; // 네일 세트 데이터 전체 전달
+  };
 
   /** AR 카메라 화면 */
   ARCameraPage: undefined;


### PR DESCRIPTION
### 🔖 관련 티켓
SN-129 ([Jira 링크](https://crusia.atlassian.net/browse/SN-129))

### 📌 작업 개요 
네일 보관함에서 내 손에 올려보기 버튼 클릭 시, 네일 세트 정보가 AR 체험 페이지로 넘어가지 않고 있습니다.
확인해보니, 미 구현 사항입니다.
네비게이션 프롭 타입 지정 및 핸들러를 수정하여 UX를 개선하겠습니다.
### ✅ 작업 항목 
바텀시트 스냅 포인트와 저장 버튼을 제거하여 보기만 가능한 하위 페이지를 제작하였습니다.
다만, 확장성을 고려하면 api 구조 설계를 바꾸는 게 옳습니다.
심지어 지금은 shape 정보를 가져올 수 없으므로 완벽하게 대응하기 위해서는 구조 변경이 필수 불가결입니다.

### 📝 추가 설명
