### PR TITLE
[FEAT] 내 손에 올려보기 이미지 라이트박스 구현 (SQ-3, SQ-21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-native-size-matters": "^0.4.2",
         "react-native-svg": "^15.11.1",
         "react-native-url-polyfill": "^2.0.0",
+        "react-native-view-shot": "^4.0.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -4953,6 +4954,15 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -5666,6 +5676,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -7929,6 +7948,19 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -11889,6 +11921,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
@@ -13225,6 +13270,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -13597,6 +13651,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-native-size-matters": "^0.4.2",
     "react-native-svg": "^15.11.1",
     "react-native-url-polyfill": "^2.0.0",
+    "react-native-view-shot": "^4.0.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/pages/ar_experience/index.tsx
+++ b/src/pages/ar_experience/index.tsx
@@ -27,8 +27,7 @@ import { toast } from '~/shared/lib/toast';
 import { CreateNailSetRequest, Shape, APIError } from '~/shared/api/types';
 import { RootStackParamList } from '~/shared/types/navigation';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import ViewShot, { captureRef } from 'react-native-view-shot';
-import Lightbox, { LightboxImage } from '~/shared/ui/Lightbox';
+import ViewshotLightbox from '~/shared/ui/Lightbox';
 import NailSelection from './ui/NailSelection';
 
 // 화면 크기 가져오기
@@ -80,11 +79,6 @@ export default function ARExperiencePage() {
 
   // 현재 선택된 네일셋 상태 (API 타입에 맞게 관리)
   const [currentNailSet, setCurrentNailSet] = useState<NailSet>({});
-
-  // 라이트박스 관련 상태
-  const [isLightboxVisible, setIsLightboxVisible] = useState(false);
-  const [capturedImage, setCapturedImage] = useState<string | null>(null);
-  const viewShotRef = useRef<ViewShot | null>(null);
 
   /**
    * 네일셋이 완전한지 확인하는 함수 (모든 손가락에 네일이 선택되었는지)
@@ -195,26 +189,6 @@ export default function ARExperiencePage() {
     </View>
   );
 
-  /**
-   * 손 이미지 영역을 캡처하고 라이트박스로 보여주는 함수
-   */
-  const captureAndShowLightbox = useCallback(() => {
-    if (viewShotRef.current) {
-      captureRef(viewShotRef).then(uri => {
-        setCapturedImage(uri);
-        setIsLightboxVisible(true);
-      });
-    }
-  }, []);
-
-  /**
-   * 라이트박스 닫기
-   */
-  const closeLightbox = useCallback(() => {
-    setIsLightboxVisible(false);
-    setCapturedImage(null); // 메모리에서 이미지 해제
-  }, []);
-
   return (
     <BottomSheetModalProvider>
       <SafeAreaView style={styles.safeArea}>
@@ -252,27 +226,22 @@ export default function ARExperiencePage() {
               </Text>
             </View>
 
-            {/* 손 이미지와 네일 오버레이 컨테이너 */}
-            <TouchableOpacity
-              activeOpacity={0.9}
-              onPress={captureAndShowLightbox}
-            >
-              <ViewShot
-                ref={viewShotRef}
-                options={{ quality: 1 }}
-                style={styles.handContainer}
-              >
-                {/* 기본 손 이미지 */}
-                <Image
-                  source={require('~/shared/assets/images/hand.png')}
-                  style={styles.handImage}
-                  resizeMode="contain"
-                />
+            {/* 손 이미지와 네일 오버레이 + ViewshotLightbox 통합 */}
+            <ViewshotLightbox
+              viewShotContent={
+                <View style={styles.handContainer}>
+                  {/* 기본 손 이미지 */}
+                  <Image
+                    source={require('~/shared/assets/images/hand.png')}
+                    style={styles.handImage}
+                    resizeMode="contain"
+                  />
 
-                {/* 네일 오버레이 - 선택된 네일팁을 손 위에 표시 */}
-                <NailOverlay nailSet={currentNailSet} />
-              </ViewShot>
-            </TouchableOpacity>
+                  {/* 네일 오버레이 - 선택된 네일팁을 손 위에 표시 */}
+                  <NailOverlay nailSet={currentNailSet} />
+                </View>
+              }
+            />
 
             {/* AR 버튼 */}
             <View style={styles.arButtonContainer}>
@@ -303,11 +272,6 @@ export default function ARExperiencePage() {
               onNailSetChange={nailSet => setCurrentNailSet(nailSet)}
             />
           </BottomSheet>
-
-          {/* 공용 Lightbox 컴포넌트 사용 */}
-          <Lightbox visible={isLightboxVisible} onClose={closeLightbox}>
-            {capturedImage && <LightboxImage uri={capturedImage} />}
-          </Lightbox>
         </View>
       </SafeAreaView>
     </BottomSheetModalProvider>

--- a/src/pages/ar_experience/index.tsx
+++ b/src/pages/ar_experience/index.tsx
@@ -28,10 +28,11 @@ import { CreateNailSetRequest, Shape, APIError } from '~/shared/api/types';
 import { RootStackParamList } from '~/shared/types/navigation';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import ViewShot, { captureRef } from 'react-native-view-shot';
+import Lightbox, { LightboxImage } from '~/shared/ui/Lightbox';
 import NailSelection from './ui/NailSelection';
 
 // 화면 크기 가져오기
-const { height, width } = Dimensions.get('window');
+const { height } = Dimensions.get('window');
 
 // 손가락 타입 정의
 export type FingerType = 'pinky' | 'ring' | 'middle' | 'index' | 'thumb';
@@ -303,20 +304,10 @@ export default function ARExperiencePage() {
             />
           </BottomSheet>
 
-          {/* 라이트박스 (position: absolute와 zIndex로 구현) */}
-          {isLightboxVisible && capturedImage && (
-            <TouchableOpacity
-              style={styles.lightboxContainer}
-              activeOpacity={1}
-              onPress={closeLightbox}
-            >
-              <Image
-                source={{ uri: capturedImage }}
-                style={styles.lightboxImage}
-                resizeMode="contain"
-              />
-            </TouchableOpacity>
-          )}
+          {/* 공용 Lightbox 컴포넌트 사용 */}
+          <Lightbox visible={isLightboxVisible} onClose={closeLightbox}>
+            {capturedImage && <LightboxImage uri={capturedImage} />}
+          </Lightbox>
         </View>
       </SafeAreaView>
     </BottomSheetModalProvider>
@@ -389,22 +380,6 @@ const styles = StyleSheet.create({
     borderRadius: 100,
     height: vs(4),
     width: scale(44),
-  },
-  lightboxContainer: {
-    alignItems: 'center',
-    backgroundColor: colors.black,
-    bottom: 0,
-    justifyContent: 'center',
-    left: 0,
-    opacity: 0.85,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    zIndex: 10000,
-  },
-  lightboxImage: {
-    height: height * 1.5,
-    width: width * 1.5,
   },
   mainTitle: {
     ...typography.head2_B,

--- a/src/pages/ar_experience/ui/NailOverlay/constants.ts
+++ b/src/pages/ar_experience/ui/NailOverlay/constants.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { scale } from '~/shared/lib/responsive';
 import { Shape } from '~/shared/api/types';
 
@@ -31,8 +32,8 @@ export const SHAPE_SIZE_RATIO: Record<
   ROUND: { width: 1, height: 1 },
   SQUARE: { width: 1.05, height: 1 },
   ALMOND: { width: 1.05, height: 1.05 },
-  BALLERINA: { width: 1.25, height: 1.1 },
-  STILETTO: { width: 1.3, height: 1.15 },
+  BALLERINA: { width: 1.1, height: 1.1 },
+  STILETTO: { width: 1.1, height: 1.15 },
 };
 
 /**
@@ -47,17 +48,14 @@ export const SHAPE_POSITION_OFFSET: Record<Shape, { x: number; y: number }> = {
   ROUND: { x: 0, y: 0 },
   SQUARE: { x: scale(-1), y: scale(-2) },
   ALMOND: { x: scale(-1), y: scale(-3) },
-  BALLERINA: { x: scale(-6.7), y: scale(-5) },
-  STILETTO: { x: scale(-7.5), y: scale(-6) },
+  BALLERINA: { x: scale(-2.5), y: scale(-5) },
+  STILETTO: { x: scale(-2.5), y: scale(-6) },
 };
 
 /**
- * 손톱별 기본 위치 정보 (ROUND 쉐입 기준)
- *
- * 좌표와 변형 값들은 기본 손 이미지를 기준으로 측정된 값입니다.
- * 해당 값들은 실제 이미지와 화면 크기에 따라 조정이 필요할 수 있습니다.
+ * iOS용 손톱별 기본 위치 정보 (ROUND 쉐입 기준)
  */
-export const BASE_NAIL_POSITIONS: Record<string, NailPosition> = {
+export const IOS_NAIL_POSITIONS: Record<string, NailPosition> = {
   // 엄지손가락 - 가장 오른쪽에 위치
   thumb: {
     x: scale(264),
@@ -99,3 +97,57 @@ export const BASE_NAIL_POSITIONS: Record<string, NailPosition> = {
     rotation: -5, // 반대 방향으로 약간 기울임
   },
 };
+
+/**
+ * Android용 손톱별 기본 위치 정보 (ROUND 쉐입 기준)
+ * Android는 일부 디바이스에서 렌더링 차이가 있을 수 있으므로 조정된 값을 사용
+ */
+export const ANDROID_NAIL_POSITIONS: Record<string, NailPosition> = {
+  // 엄지손가락 - 가장 오른쪽에 위치
+  thumb: {
+    x: scale(259),
+    y: scale(129),
+    width: scale(58),
+    height: scale(50),
+    rotation: 25,
+  },
+  // 검지손가락
+  index: {
+    x: scale(201),
+    y: scale(26),
+    width: scale(47),
+    height: scale(33),
+    rotation: 1,
+  },
+  // 중지손가락
+  middle: {
+    x: scale(159.5),
+    y: scale(5),
+    width: scale(52),
+    height: scale(37),
+    rotation: 1,
+  },
+  // 약지손가락
+  ring: {
+    x: scale(119.5),
+    y: scale(30),
+    width: scale(47),
+    height: scale(33),
+    rotation: -2,
+  },
+  // 소지손가락 - 가장 왼쪽에 위치
+  pinky: {
+    x: scale(84),
+    y: scale(85),
+    width: scale(37),
+    height: scale(28),
+    rotation: -5,
+  },
+};
+
+/**
+ * 플랫폼에 따른 손톱별 기본 위치 정보
+ * iOS와 Android에서 각각 최적화된 위치 값 사용
+ */
+export const BASE_NAIL_POSITIONS =
+  Platform.OS === 'ios' ? IOS_NAIL_POSITIONS : ANDROID_NAIL_POSITIONS;

--- a/src/shared/ui/Lightbox/index.tsx
+++ b/src/shared/ui/Lightbox/index.tsx
@@ -1,0 +1,100 @@
+import React, { ReactNode } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  StyleSheet,
+  Dimensions,
+  Image,
+  StyleProp,
+  ViewStyle,
+  ImageStyle,
+} from 'react-native';
+import { colors } from '~/shared/styles/design';
+
+// 화면 크기 가져오기
+const { height, width } = Dimensions.get('window');
+
+interface LightboxProps {
+  visible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  containerStyle?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle | ImageStyle>;
+  backgroundOpacity?: number;
+}
+
+/**
+ * 라이트박스 컴포넌트
+ *
+ * 이미지나 기타 콘텐츠를 전체 화면으로 확대해서 보여주는 공용 컴포넌트입니다.
+ * ViewShot으로 캡처한 이미지나 일반 이미지, 또는 다른 React 컴포넌트를 표시할 수 있습니다.
+ *
+ * @param {boolean} visible - 라이트박스 표시 여부
+ * @param {() => void} onClose - 라이트박스 닫기 이벤트 핸들러
+ * @param {ReactNode} children - 라이트박스에 표시할 콘텐츠
+ * @param {StyleProp<ViewStyle>} containerStyle - 컨테이너 스타일 (선택 사항)
+ * @param {StyleProp<ViewStyle | ImageStyle>} contentStyle - 콘텐츠 스타일 (선택 사항)
+ * @param {number} backgroundOpacity - 배경 불투명도 (선택 사항, 기본값: 0.85)
+ *
+ * @returns {JSX.Element | null} 라이트박스 컴포넌트 또는 visible이 false인 경우 null
+ */
+export default function Lightbox({
+  visible,
+  onClose,
+  children,
+  containerStyle,
+  contentStyle,
+  backgroundOpacity = 0.85,
+}: LightboxProps) {
+  if (!visible) return null;
+
+  return (
+    <TouchableOpacity
+      style={[styles.container, { opacity: backgroundOpacity }, containerStyle]}
+      activeOpacity={1}
+      onPress={onClose}
+    >
+      <View style={[styles.content, contentStyle]}>{children}</View>
+    </TouchableOpacity>
+  );
+}
+
+// 라이트박스용 이미지 컴포넌트 - 자주 사용하는 패턴
+export function LightboxImage({
+  uri,
+  style,
+}: {
+  uri: string;
+  style?: StyleProp<ImageStyle>;
+}) {
+  return (
+    <Image
+      source={{ uri }}
+      style={[styles.image, style]}
+      resizeMode="contain"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.black,
+    height,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 10000,
+  },
+  content: {
+    alignItems: 'center',
+    height: '100%',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  image: {
+    height: height * 1.5,
+    width: width * 1.5,
+  },
+});

--- a/src/shared/ui/Lightbox/index.tsx
+++ b/src/shared/ui/Lightbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useCallback, useRef, useState } from 'react';
 import {
   View,
   TouchableOpacity,
@@ -8,26 +8,32 @@ import {
   StyleProp,
   ViewStyle,
   ImageStyle,
+  ActivityIndicator,
 } from 'react-native';
 import { colors } from '~/shared/styles/design';
+import ViewShot, { captureRef } from 'react-native-view-shot';
 
 // 화면 크기 가져오기
 const { height, width } = Dimensions.get('window');
 
 interface LightboxProps {
-  visible: boolean;
-  onClose: () => void;
   children: ReactNode;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle | ImageStyle>;
   backgroundOpacity?: number;
 }
 
+interface ViewshotLightboxProps extends Omit<LightboxProps, 'children'> {
+  viewShotContent: ReactNode;
+  customLightboxContent?: ReactNode;
+  onCapture?: (uri: string) => void;
+  captureQuality?: number;
+}
+
 /**
  * 라이트박스 컴포넌트
  *
  * 이미지나 기타 콘텐츠를 전체 화면으로 확대해서 보여주는 공용 컴포넌트입니다.
- * ViewShot으로 캡처한 이미지나 일반 이미지, 또는 다른 React 컴포넌트를 표시할 수 있습니다.
  *
  * @param {boolean} visible - 라이트박스 표시 여부
  * @param {() => void} onClose - 라이트박스 닫기 이벤트 핸들러
@@ -38,14 +44,17 @@ interface LightboxProps {
  *
  * @returns {JSX.Element | null} 라이트박스 컴포넌트 또는 visible이 false인 경우 null
  */
-export default function Lightbox({
+export function Lightbox({
   visible,
   onClose,
   children,
   containerStyle,
   contentStyle,
   backgroundOpacity = 0.85,
-}: LightboxProps) {
+}: {
+  visible: boolean;
+  onClose: () => void;
+} & LightboxProps) {
   if (!visible) return null;
 
   return (
@@ -59,6 +68,77 @@ export default function Lightbox({
   );
 }
 
+/**
+ * ViewShot과 통합된 라이트박스 컴포넌트
+ *
+ * 지정된 콘텐츠를 ViewShot으로 캡처하고 라이트박스에 표시합니다.
+ *
+ * @param {ReactNode} viewShotContent - 캡처할 콘텐츠
+ * @param {ReactNode} customLightboxContent - 라이트박스에 표시할 커스텀 콘텐츠 (옵션)
+ * @param {(uri: string) => void} onCapture - 캡처 완료 후 콜백 (옵션)
+ * @param {StyleProp<ViewStyle>} containerStyle - 컨테이너 스타일 (선택 사항)
+ * @param {StyleProp<ViewStyle | ImageStyle>} contentStyle - 콘텐츠 스타일 (선택 사항)
+ * @param {number} backgroundOpacity - 배경 불투명도 (선택 사항, 기본값: 0.85)
+ * @param {number} captureQuality - 캡처 이미지 품질 (선택 사항, 기본값: 1)
+ *
+ * @returns {JSX.Element} ViewShot 래핑 컴포넌트와 라이트박스
+ */
+export default function ViewshotLightbox({
+  viewShotContent,
+  customLightboxContent,
+  onCapture,
+  containerStyle,
+  contentStyle,
+  backgroundOpacity = 0.85,
+  captureQuality = 1,
+}: ViewshotLightboxProps) {
+  // 라이트박스 관련 상태
+  const [isLightboxVisible, setIsLightboxVisible] = useState(false);
+  const [capturedImage, setCapturedImage] = useState<string | null>(null);
+  const viewShotRef = useRef<ViewShot | null>(null);
+
+  /**
+   * 콘텐츠를 캡처하고 라이트박스로 표시하는 함수
+   */
+  const captureAndShowLightbox = useCallback(() => {
+    if (viewShotRef.current) {
+      captureRef(viewShotRef, { quality: captureQuality }).then(uri => {
+        setCapturedImage(uri);
+        setIsLightboxVisible(true);
+        onCapture?.(uri);
+      });
+    }
+  }, [captureQuality, onCapture]);
+
+  /**
+   * 라이트박스 닫기
+   */
+  const closeLightbox = useCallback(() => {
+    setIsLightboxVisible(false);
+  }, []);
+
+  return (
+    <>
+      <TouchableOpacity activeOpacity={0.9} onPress={captureAndShowLightbox}>
+        <ViewShot ref={viewShotRef} options={{ quality: captureQuality }}>
+          {viewShotContent}
+        </ViewShot>
+      </TouchableOpacity>
+
+      <Lightbox
+        visible={isLightboxVisible}
+        onClose={closeLightbox}
+        containerStyle={containerStyle}
+        contentStyle={contentStyle}
+        backgroundOpacity={backgroundOpacity}
+      >
+        {customLightboxContent ||
+          (capturedImage && <LightboxImage uri={capturedImage} />)}
+      </Lightbox>
+    </>
+  );
+}
+
 // 라이트박스용 이미지 컴포넌트 - 자주 사용하는 패턴
 export function LightboxImage({
   uri,
@@ -67,19 +147,30 @@ export function LightboxImage({
   uri: string;
   style?: StyleProp<ImageStyle>;
 }) {
+  const [isLoading, setIsLoading] = useState(true);
+
   return (
-    <Image
-      source={{ uri }}
-      style={[styles.image, style]}
-      resizeMode="contain"
-    />
+    <View style={styles.imageContainer}>
+      {isLoading && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.white} />
+        </View>
+      )}
+      <Image
+        source={{ uri }}
+        style={[styles.image, style]}
+        resizeMode="contain"
+        onLoad={() => setIsLoading(false)}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    alignItems: 'center',
     backgroundColor: colors.black,
-    height,
+    bottom: 0,
     justifyContent: 'center',
     left: 0,
     position: 'absolute',
@@ -89,12 +180,26 @@ const styles = StyleSheet.create({
   },
   content: {
     alignItems: 'center',
-    height: '100%',
+    flex: 1,
     justifyContent: 'center',
     width: '100%',
   },
   image: {
     height: height * 1.5,
+    resizeMode: 'contain',
     width: width * 1.5,
+  },
+  imageContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
 });


### PR DESCRIPTION
### 🔖 관련 티켓
SN-137 ([Jira 링크](https://crusia.atlassian.net/browse/SN-137))

### 📌 작업 개요 
내 손에 올려보기 이미지 클릭 시 더 커진 플로팅 이미지를 제공합니다.
### ✅ 작업 항목 
- 임시 캡쳐 형식의 라이트박스 구현
- 플랫폼 별 네일 위치 오프셋 분리
- SQ-21 조금 더 자연스러운 네일-팁 오버레이 수정
추가된 패키지:
"react-native-view-shot": "^4.0.3"


### 📝 추가 설명
네일 오버레이를 더 깔끔하게 구현해야 하는데, 손 이미지에 비해 네일 비율이 길쭉해서 뭉그러지네요.
디자인 쪽과 얘기해볼 필요가 있습니다.