### PR TITLE
[FEAT] 손톱 각도·크기 계산 로직 구현

### DIFF
--- a/ios/Modules/NailMetricsAnalyzer.swift
+++ b/ios/Modules/NailMetricsAnalyzer.swift
@@ -1,0 +1,104 @@
+import UIKit
+import Vision
+
+class NailMetricsAnalyzer: NailMetricsAnalyzing {
+    
+    // 손가락 관절 매핑 정보 (DIP 및 TIP 관절 정의)
+    static let fingerJointMapping: [(name: String, dip: VNHumanHandPoseObservation.JointName, tip: VNHumanHandPoseObservation.JointName)] = [
+        ("thumb", .thumbIP, .thumbTip),
+        ("index", .indexDIP, .indexTip),
+        ("middle", .middleDIP, .middleTip),
+        ("ring", .ringDIP, .ringTip),
+        ("pinky", .littleDIP, .littleTip)
+    ]
+    
+    func calculateAllFingerMetrics(
+        observation: VNHumanHandPoseObservation,
+        contours: [(path: UIBezierPath, center: CGPoint)],
+        displaySize: CGSize
+    ) -> [NailMetrics] {
+        var results: [NailMetrics] = []
+        
+        guard let recognizedPoints = try? observation.recognizedPoints(.all) else {
+            print("인식된 관절 정보 없음")
+            return []
+        }
+        
+        for (name, dipJoint, tipJoint) in NailMetricsAnalyzer.fingerJointMapping {
+            guard let dipPointValue = recognizedPoints[dipJoint],
+                  let tipPointValue = recognizedPoints[tipJoint],
+                  dipPointValue.confidence > 0.2,
+                  tipPointValue.confidence > 0.2 else {
+                print("\(name) 손가락 관절 정보 부족")
+                continue
+            }
+            
+            let dipPoint = CGPoint(
+                x: dipPointValue.location.x * displaySize.width,
+                y: (1 - dipPointValue.location.y) * displaySize.height
+            )
+            let tipPoint = CGPoint(
+                x: tipPointValue.location.x * displaySize.width,
+                y: (1 - tipPointValue.location.y) * displaySize.height
+            )
+            
+            var closestContour: UIBezierPath?
+            var closestCenter: CGPoint?
+            var minDistance: CGFloat = CGFloat.greatestFiniteMagnitude
+            
+            for (contour, center) in contours {
+                let distance = hypot(center.x - tipPoint.x, center.y - tipPoint.y)
+                if distance < minDistance {
+                    minDistance = distance
+                    closestContour = contour
+                    closestCenter = center
+                }
+            }
+            
+            guard let contour = closestContour, let center = closestCenter else {
+                print("\(name) 손가락에 적합한 컨투어 없음")
+                continue
+            }
+            
+            let (angle, width, height) = Self.calculateNailMetrics(
+                contour: contour,
+                dipPoint: dipPoint,
+                tipPoint: tipPoint
+            )
+            
+            let metrics = NailMetrics(
+                fingerName: name,
+                contourCenter: center,
+                angle: angle,
+                width: width,
+                height: height,
+                dipPoint: dipPoint,
+                tipPoint: tipPoint
+            )
+            results.append(metrics)
+        }
+        return results
+    }
+    
+    static func calculateNailMetrics(
+        contour: UIBezierPath,
+        dipPoint: CGPoint,
+        tipPoint: CGPoint
+    ) -> (angle: CGFloat, width: CGFloat, height: CGFloat) {
+        let center = CGPoint(x: contour.bounds.midX, y: contour.bounds.midY)
+        let dx = tipPoint.x - dipPoint.x
+        let dy = tipPoint.y - dipPoint.y
+        
+        let angle = atan2(dx, -dy)
+        let degrees = angle * 180 / .pi
+        
+        let copy = contour.copy() as! UIBezierPath
+        let translateTransform = CGAffineTransform(translationX: -center.x, y: -center.y)
+        copy.apply(translateTransform)
+        let rotateTransform = CGAffineTransform(rotationAngle: -angle)
+        copy.apply(rotateTransform)
+        let bounds = copy.bounds
+        
+        return (degrees, bounds.width, bounds.height)
+    }
+}

--- a/ios/Protocols/NailMetricsAnalyzing.swift
+++ b/ios/Protocols/NailMetricsAnalyzing.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+// 전역 또는 별도 파일에 정의된 NailMetrics 타입
+struct NailMetrics {
+    let fingerName: String          // 예: "thumb", "index", etc.
+    let contourCenter: CGPoint      // 컨투어 중심점
+    let angle: CGFloat              // DIP→TIP 방향의 각도 (도 단위)
+    let width: CGFloat              // 컨투어의 너비
+    let height: CGFloat             // 컨투어의 높이
+    let dipPoint: CGPoint           // DIP 관절 위치
+    let tipPoint: CGPoint           // TIP 관절 위치
+}
+
+import Vision
+
+protocol NailMetricsAnalyzing {
+    func calculateAllFingerMetrics(
+        observation: VNHumanHandPoseObservation,
+        contours: [(path: UIBezierPath, center: CGPoint)],
+        displaySize: CGSize
+    ) -> [NailMetrics]
+}

--- a/ios/nailian.xcodeproj/project.pbxproj
+++ b/ios/nailian.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		473BFEFAD123086068F6BFCD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		7699B88040F8A987B510C191 /* libPods-nailian-nailianTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-nailian-nailianTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13842692DB764EF00631A7F /* ContourAnalyzing.swift */; };
+		E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */; };
+		E138426F2DB764F500631A7F /* NailMetricsAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */; };
 		E14D840E2D8D740700EDD138 /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */; };
 		E14D840F2D8D740700EDD138 /* Pretendard-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */; };
 		E14D84102D8D740700EDD138 /* Pretendard-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */; };
@@ -70,6 +73,9 @@
 		C8D7FE748B344A429ACD3F64 /* Pretendard-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraBold.ttf"; sourceTree = "<group>"; };
 		CB4F9DE9ABA54B6093085640 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.ttf"; path = "../src/shared/assets/fonts/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
 		E1112B902DA009390021E94C /* nailian.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = nailian.entitlements; path = nailian/nailian.entitlements; sourceTree = "<group>"; };
+		E13842692DB764EF00631A7F /* ContourAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContourAnalyzing.swift; sourceTree = "<group>"; };
+		E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandPoseDetecting.swift; sourceTree = "<group>"; };
+		E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NailMetricsAnalyzing.swift; sourceTree = "<group>"; };
 		E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libRNKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1E0C2642D8C157B0053273B /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E1E0C2652D8C157B0053273B /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
@@ -84,15 +90,11 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		E14D84192D8D7C6E00EDD138 /* Modules */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Modules;
 			sourceTree = "<group>";
 		};
 		E1D033572D8E8DB900C244AD /* Models */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -142,6 +144,7 @@
 		13B07FAE1A68108700A75B9A /* nailian */ = {
 			isa = PBXGroup;
 			children = (
+				E138426B2DB764EF00631A7F /* Protocols */,
 				E1F0762C2DA4AF86003F928C /* Assets.xcassets */,
 				E1112B902DA009390021E94C /* nailian.entitlements */,
 				E1D033572D8E8DB900C244AD /* Models */,
@@ -230,6 +233,16 @@
 				89C6BE57DB24E9ADA2F236DE /* Pods-nailian-nailianTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		E138426B2DB764EF00631A7F /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */,
+				E13842692DB764EF00631A7F /* ContourAnalyzing.swift */,
+				E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -494,7 +507,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
+				E138426F2DB764F500631A7F /* NailMetricsAnalyzing.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */,
+				E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -691,10 +707,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -765,10 +778,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;


### PR DESCRIPTION
### 🔖 관련 티켓
SN-145 ([Jira 링크](https://crusia.atlassian.net/browse/SN-145))

### 📌 작업 개요 
각 손톱의 방향(각도) 과 치수(너비·높이) 를 계산하는 로직을 구현
### ✅ 작업 항목 
- NailMetricsAnalyzer 클래스 추가 및 프로토콜 구현
- DIP·TIP 관절 포인트를 화면 좌표로 변환
- 손끝에 가장 가까운 컨투어 중심 찾기
- 컨투어 회전 후 바운딩 박스 너비·높이 및 각도 계산
- 5개 손가락 메트릭스 일괄 계산 및 NailMetrics 반환