### PR TITLE
[FEAT] 네일 에셋 관리 모듈 추가

### DIFF
--- a/ios/Modules/NailAssetProvider.swift
+++ b/ios/Modules/NailAssetProvider.swift
@@ -1,0 +1,201 @@
+import UIKit
+
+class NailAssetProvider: NailAssetProviding {
+    // 타입 별칭으로 프로토콜의 관련 타입 정의
+    typealias FingerTypeEnum = FingerType
+    typealias NailShapeEnum = NailShape
+    typealias NailInfoType = NailInfo
+    
+    // 싱글톤 인스턴스
+    static let shared = NailAssetProvider()
+    
+    // 손가락 타입 정의
+    enum FingerType: Int {
+        case thumb = 0
+        case index = 1
+        case middle = 2
+        case ring = 3
+        case pinky = 4
+        
+        func toString() -> String {
+            switch self {
+            case .thumb: return "thumb"
+            case .index: return "index"
+            case .middle: return "middle"
+            case .ring: return "ring"
+            case .pinky: return "pinky"
+            }
+        }
+    }
+    
+    // 네일 모양 타입 정의
+    enum NailShape: Int {
+        case square = 0
+        case round = 1
+        case almond = 2
+        case ballerina = 3
+        case stiletto = 4
+        
+        func toString() -> String {
+            switch self {
+            case .square: return "SQUARE"
+            case .round: return "ROUND"
+            case .almond: return "ALMOND"
+            case .ballerina: return "BALLERINA"
+            case .stiletto: return "STILETTO"
+            }
+        }
+        
+        static func fromString(_ string: String) -> NailShape {
+            switch string.uppercased() {
+            case "SQUARE": return .square
+            case "ROUND": return .round
+            case "ALMOND": return .almond
+            case "BALLERINA": return .ballerina
+            case "STILETTO": return .stiletto
+            default: return .round
+            }
+        }
+    }
+    
+    // 네일 세트 정보 구조체
+    struct NailInfo {
+        let imageUrl: String
+        let shape: NailShape
+        var image: UIImage?
+    }
+    
+    // 각 손가락 타입별 네일 정보 저장
+    var nailSets: [FingerType: NailInfo] = [:]
+    
+    // 이미지 캐시
+    private let imageCache = NSCache<NSString, UIImage>()
+    
+    private init() {
+        // 초기화 코드
+    }
+    
+    // 네일 세트 데이터 설정
+    func setNailSet(_ nailSetDict: [String: Any]) {
+        for (fingerKey, fingerData) in nailSetDict {
+            if let fingerDict = fingerData as? [String: Any],
+               let imageUrl = fingerDict["imageUrl"] as? String,
+               let shapeStr = fingerDict["shape"] as? String {
+                
+                let fingerType: FingerType
+                switch fingerKey {
+                case "thumb": fingerType = .thumb
+                case "index": fingerType = .index
+                case "middle": fingerType = .middle
+                case "ring": fingerType = .ring
+                case "pinky": fingerType = .pinky
+                default: continue
+                }
+                
+                nailSets[fingerType] = NailInfo(
+                    imageUrl: imageUrl,
+                    shape: NailShape.fromString(shapeStr)
+                )
+            }
+        }
+        
+        print("네일 세트 설정 완료: \(nailSets)")
+    }
+    
+    // 특정 손가락 타입의 네일 정보 반환
+    func getNailSetForFingerType(_ fingerType: FingerType) -> NailInfo? {
+        return nailSets[fingerType]
+    }
+    
+    // 손가락 타입 이름 반환
+    func fingerName(_ fingerType: FingerType) -> String {
+        switch fingerType {
+        case .thumb: return "엄지"
+        case .index: return "검지"
+        case .middle: return "중지"
+        case .ring: return "약지"
+        case .pinky: return "소지"
+        }
+    }
+    
+    // 네일 모양 이름 반환
+    func shapeName(_ shape: NailShape) -> String {
+        switch shape {
+        case .square: return "스퀘어"
+        case .round: return "라운드"
+        case .almond: return "아몬드"
+        case .ballerina: return "발레리나"
+        case .stiletto: return "스틸레토"
+        }
+    }
+    
+    // 네일 이미지 다운로드
+    static func downloadImage(from urlString: String, completion: @escaping (UIImage?) -> Void) {
+        // 캐시된 이미지가 있는지 확인
+        let cacheKey = NSString(string: urlString)
+        if let cachedImage = shared.imageCache.object(forKey: cacheKey) {
+            print("캐시에서 이미지 로드: \(urlString)")
+            completion(cachedImage)
+            return
+        }
+        
+        // URL 생성
+        guard let url = URL(string: urlString) else {
+            print("유효하지 않은 URL: \(urlString)")
+            completion(nil)
+            return
+        }
+        
+        // 네트워크 요청
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("이미지 다운로드 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+                return
+            }
+            
+            guard let data = data, let image = UIImage(data: data) else {
+                print("이미지 데이터 변환 실패")
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+                return
+            }
+            
+            // 캐시에 저장
+            shared.imageCache.setObject(image, forKey: cacheKey)
+            print("이미지 다운로드 및 캐시 성공: \(urlString)")
+            
+            DispatchQueue.main.async {
+                completion(image)
+            }
+        }
+        
+        print("이미지 다운로드 시작: \(urlString)")
+        task.resume()
+    }
+    
+    // 네일 이미지 로딩
+    func loadNailImage(for fingerType: FingerType, completion: @escaping (UIImage?) -> Void) {
+        // 해당 손가락의 네일 정보 가져오기
+        guard let nailInfo = getNailSetForFingerType(fingerType) else {
+            print("\(fingerName(fingerType)) 손가락의 네일 정보가 없습니다.")
+            completion(nil)
+            return
+        }
+        
+        print("\(fingerName(fingerType)) 손가락에 \(shapeName(nailInfo.shape)) 모양의 네일 적용")
+        
+        // 네일 이미지 로드만 수행
+        NailAssetProvider.downloadImage(from: nailInfo.imageUrl) { [weak self] image in
+            guard let _ = self, let nailImage = image else {
+                print("네일 이미지 로드 실패")
+                completion(nil)
+                return
+            }
+            completion(nailImage)
+        }
+    }
+}

--- a/ios/Modules/NailMetricsAnalyzer.swift
+++ b/ios/Modules/NailMetricsAnalyzer.swift
@@ -1,0 +1,104 @@
+import UIKit
+import Vision
+
+class NailMetricsAnalyzer: NailMetricsAnalyzing {
+    
+    // 손가락 관절 매핑 정보 (DIP 및 TIP 관절 정의)
+    static let fingerJointMapping: [(name: String, dip: VNHumanHandPoseObservation.JointName, tip: VNHumanHandPoseObservation.JointName)] = [
+        ("thumb", .thumbIP, .thumbTip),
+        ("index", .indexDIP, .indexTip),
+        ("middle", .middleDIP, .middleTip),
+        ("ring", .ringDIP, .ringTip),
+        ("pinky", .littleDIP, .littleTip)
+    ]
+    
+    func calculateAllFingerMetrics(
+        observation: VNHumanHandPoseObservation,
+        contours: [(path: UIBezierPath, center: CGPoint)],
+        displaySize: CGSize
+    ) -> [NailMetrics] {
+        var results: [NailMetrics] = []
+        
+        guard let recognizedPoints = try? observation.recognizedPoints(.all) else {
+            print("인식된 관절 정보 없음")
+            return []
+        }
+        
+        for (name, dipJoint, tipJoint) in NailMetricsAnalyzer.fingerJointMapping {
+            guard let dipPointValue = recognizedPoints[dipJoint],
+                  let tipPointValue = recognizedPoints[tipJoint],
+                  dipPointValue.confidence > 0.2,
+                  tipPointValue.confidence > 0.2 else {
+                print("\(name) 손가락 관절 정보 부족")
+                continue
+            }
+            
+            let dipPoint = CGPoint(
+                x: dipPointValue.location.x * displaySize.width,
+                y: (1 - dipPointValue.location.y) * displaySize.height
+            )
+            let tipPoint = CGPoint(
+                x: tipPointValue.location.x * displaySize.width,
+                y: (1 - tipPointValue.location.y) * displaySize.height
+            )
+            
+            var closestContour: UIBezierPath?
+            var closestCenter: CGPoint?
+            var minDistance: CGFloat = CGFloat.greatestFiniteMagnitude
+            
+            for (contour, center) in contours {
+                let distance = hypot(center.x - tipPoint.x, center.y - tipPoint.y)
+                if distance < minDistance {
+                    minDistance = distance
+                    closestContour = contour
+                    closestCenter = center
+                }
+            }
+            
+            guard let contour = closestContour, let center = closestCenter else {
+                print("\(name) 손가락에 적합한 컨투어 없음")
+                continue
+            }
+            
+            let (angle, width, height) = Self.calculateNailMetrics(
+                contour: contour,
+                dipPoint: dipPoint,
+                tipPoint: tipPoint
+            )
+            
+            let metrics = NailMetrics(
+                fingerName: name,
+                contourCenter: center,
+                angle: angle,
+                width: width,
+                height: height,
+                dipPoint: dipPoint,
+                tipPoint: tipPoint
+            )
+            results.append(metrics)
+        }
+        return results
+    }
+    
+    static func calculateNailMetrics(
+        contour: UIBezierPath,
+        dipPoint: CGPoint,
+        tipPoint: CGPoint
+    ) -> (angle: CGFloat, width: CGFloat, height: CGFloat) {
+        let center = CGPoint(x: contour.bounds.midX, y: contour.bounds.midY)
+        let dx = tipPoint.x - dipPoint.x
+        let dy = tipPoint.y - dipPoint.y
+        
+        let angle = atan2(dx, -dy)
+        let degrees = angle * 180 / .pi
+        
+        let copy = contour.copy() as! UIBezierPath
+        let translateTransform = CGAffineTransform(translationX: -center.x, y: -center.y)
+        copy.apply(translateTransform)
+        let rotateTransform = CGAffineTransform(rotationAngle: -angle)
+        copy.apply(rotateTransform)
+        let bounds = copy.bounds
+        
+        return (degrees, bounds.width, bounds.height)
+    }
+}

--- a/ios/Protocols/NailAssetProviding.swift
+++ b/ios/Protocols/NailAssetProviding.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+/// 네일 에셋 제공 서비스를 위한 프로토콜
+protocol NailAssetProviding {
+    /// 손가락 타입 (enum 타입은 프로토콜에서 직접 정의할 수 없어 연관 타입으로 선언)
+    associatedtype FingerTypeEnum: RawRepresentable & Hashable where FingerTypeEnum.RawValue == Int
+    
+    /// 네일 형태 타입 (enum 타입은 프로토콜에서 직접 정의할 수 없어 연관 타입으로 선언)
+    associatedtype NailShapeEnum: RawRepresentable where NailShapeEnum.RawValue == Int
+    
+    /// 네일 정보 구조체 타입
+    associatedtype NailInfoType
+    
+    /// 네일 세트 정보를 저장하는 딕셔너리
+    var nailSets: [FingerTypeEnum: NailInfoType] { get set }
+    
+    /// 네일 세트 데이터 설정
+    func setNailSet(_ nailSetDict: [String: Any])
+    
+    /// 특정 손가락 타입의 네일 정보 반환
+    func getNailSetForFingerType(_ fingerType: FingerTypeEnum) -> NailInfoType?
+    
+    /// 네일 이미지 로딩
+    func loadNailImage(for fingerType: FingerTypeEnum, completion: @escaping (UIImage?) -> Void)
+    
+    /// 네일 이미지 다운로드 (정적 메서드)
+    static func downloadImage(from urlString: String, completion: @escaping (UIImage?) -> Void)
+} 

--- a/ios/Protocols/NailMetricsAnalyzing.swift
+++ b/ios/Protocols/NailMetricsAnalyzing.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+// 전역 또는 별도 파일에 정의된 NailMetrics 타입
+struct NailMetrics {
+    let fingerName: String          // 예: "thumb", "index", etc.
+    let contourCenter: CGPoint      // 컨투어 중심점
+    let angle: CGFloat              // DIP→TIP 방향의 각도 (도 단위)
+    let width: CGFloat              // 컨투어의 너비
+    let height: CGFloat             // 컨투어의 높이
+    let dipPoint: CGPoint           // DIP 관절 위치
+    let tipPoint: CGPoint           // TIP 관절 위치
+}
+
+import Vision
+
+protocol NailMetricsAnalyzing {
+    func calculateAllFingerMetrics(
+        observation: VNHumanHandPoseObservation,
+        contours: [(path: UIBezierPath, center: CGPoint)],
+        displaySize: CGSize
+    ) -> [NailMetrics]
+}

--- a/ios/nailian.xcodeproj/project.pbxproj
+++ b/ios/nailian.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13842692DB764EF00631A7F /* ContourAnalyzing.swift */; };
 		E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */; };
 		E138426F2DB764F500631A7F /* NailMetricsAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */; };
+		E13842862DB7698500631A7F /* NailAssetProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13842852DB7697D00631A7F /* NailAssetProviding.swift */; };
 		E14D840E2D8D740700EDD138 /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */; };
 		E14D840F2D8D740700EDD138 /* Pretendard-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */; };
 		E14D84102D8D740700EDD138 /* Pretendard-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */; };
@@ -76,6 +77,7 @@
 		E13842692DB764EF00631A7F /* ContourAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContourAnalyzing.swift; sourceTree = "<group>"; };
 		E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandPoseDetecting.swift; sourceTree = "<group>"; };
 		E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NailMetricsAnalyzing.swift; sourceTree = "<group>"; };
+		E13842852DB7697D00631A7F /* NailAssetProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NailAssetProviding.swift; sourceTree = "<group>"; };
 		E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libRNKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1E0C2642D8C157B0053273B /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E1E0C2652D8C157B0053273B /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 		E138426B2DB764EF00631A7F /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
+				E13842852DB7697D00631A7F /* NailAssetProviding.swift */,
 				E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */,
 				E13842692DB764EF00631A7F /* ContourAnalyzing.swift */,
 				E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */,
@@ -511,6 +514,7 @@
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */,
 				E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */,
+				E13842862DB7698500631A7F /* NailAssetProviding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/nailian.xcodeproj/project.pbxproj
+++ b/ios/nailian.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		473BFEFAD123086068F6BFCD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		7699B88040F8A987B510C191 /* libPods-nailian-nailianTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-nailian-nailianTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13842692DB764EF00631A7F /* ContourAnalyzing.swift */; };
+		E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */; };
+		E138426F2DB764F500631A7F /* NailMetricsAnalyzing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */; };
 		E14D840E2D8D740700EDD138 /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C58AFF360BBE4F84A816AC89 /* Pretendard-SemiBold.ttf */; };
 		E14D840F2D8D740700EDD138 /* Pretendard-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4548124832A749DAA5A2903A /* Pretendard-ExtraLight.ttf */; };
 		E14D84102D8D740700EDD138 /* Pretendard-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F6F6624F647A4D35B9A96978 /* Pretendard-Thin.ttf */; };
@@ -70,6 +73,9 @@
 		C8D7FE748B344A429ACD3F64 /* Pretendard-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-ExtraBold.ttf"; path = "../src/shared/assets/fonts/Pretendard-ExtraBold.ttf"; sourceTree = "<group>"; };
 		CB4F9DE9ABA54B6093085640 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.ttf"; path = "../src/shared/assets/fonts/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
 		E1112B902DA009390021E94C /* nailian.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = nailian.entitlements; path = nailian/nailian.entitlements; sourceTree = "<group>"; };
+		E13842692DB764EF00631A7F /* ContourAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContourAnalyzing.swift; sourceTree = "<group>"; };
+		E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandPoseDetecting.swift; sourceTree = "<group>"; };
+		E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NailMetricsAnalyzing.swift; sourceTree = "<group>"; };
 		E16EA9A02D7815BF0056AA4B /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libRNKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1E0C2642D8C157B0053273B /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E1E0C2652D8C157B0053273B /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
@@ -84,15 +90,11 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		E14D84192D8D7C6E00EDD138 /* Modules */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Modules;
 			sourceTree = "<group>";
 		};
 		E1D033572D8E8DB900C244AD /* Models */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -142,6 +144,7 @@
 		13B07FAE1A68108700A75B9A /* nailian */ = {
 			isa = PBXGroup;
 			children = (
+				E138426B2DB764EF00631A7F /* Protocols */,
 				E1F0762C2DA4AF86003F928C /* Assets.xcassets */,
 				E1112B902DA009390021E94C /* nailian.entitlements */,
 				E1D033572D8E8DB900C244AD /* Models */,
@@ -230,6 +233,16 @@
 				89C6BE57DB24E9ADA2F236DE /* Pods-nailian-nailianTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		E138426B2DB764EF00631A7F /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				E138426E2DB764F200631A7F /* NailMetricsAnalyzing.swift */,
+				E13842692DB764EF00631A7F /* ContourAnalyzing.swift */,
+				E138426A2DB764EF00631A7F /* HandPoseDetecting.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -494,7 +507,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
+				E138426F2DB764F500631A7F /* NailMetricsAnalyzing.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				E138426C2DB764EF00631A7F /* ContourAnalyzing.swift in Sources */,
+				E138426D2DB764EF00631A7F /* HandPoseDetecting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -691,10 +707,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -765,10 +778,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;


### PR DESCRIPTION
### 🔖 관련 티켓
SN-144 ([Jira 링크](https://crusia.atlassian.net/browse/SN-144))

### 📌 작업 개요 
URL 기반으로 각 손가락별 네일 이미지를 다운로드·캐싱하고,  전역에서 조회할 수 있는 네일 에셋 관리 모듈을 추가
### ✅ 작업 항목 
- NailAssetProvider 클래스 추가 및 NailAssetProviding 프로토콜 구현
- 손가락 타입(FingerType) 및 네일 모양(NailShape) enum 정의
- setNailSet(_:) 메서드로 네일 세트 데이터 초기화
- downloadImage(from:) 비동기 이미지 다운로드 로직 구현
- NSCache 기반 이미지 캐싱 기능 적용
- loadNailImage(for:) 메서드로 캐시/다운로드된 네일 이미지 반환
- 다운로드 실패·URL 오류 시 로그 출력 및 nil 처리